### PR TITLE
fixes (again) installation with ocamlfind

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -384,8 +384,10 @@ ifeq (@LABLGNOMECANVAS@,yes)
 	$(OCAMLFIND) install ocamlgraph META \
 		$(SRCDIR)/*.mli $(VIEWER_DIR)/*.mli $(DGRAPH_DIR)/*.mli \
 		graph$(LIBEXT) graph.cmx graph.cmo graph.cmi $(CMA) $(CMXA) \
-		$(VIEWER_CMXLIB) $(VIEWER_CMOLIB) $(DGRAPH_CMXLIB) \
-		$(DGRAPH_CMOLIB) $(DGRAPH_CMILIB)
+		$(VIEWER_CMXLIB) $(VIEWER_CMOLIB) $(VIEWER_CMILIB) \
+                $(VIEWER_CMXLIB:.cmx=.o) \
+                $(DGRAPH_CMXLIB) $(DGRAPH_CMOLIB) $(DGRAPH_CMILIB) \
+                $(DGRAPH_CMXLIB:.cmx=.o)
 else
 	$(OCAMLFIND) install ocamlgraph META \
 		$(SRCDIR)/*.mli $(VIEWER_DIR)/*.mli $(DGRAPH_DIR)/*.mli \


### PR DESCRIPTION
commit 0eba52e72bde07b4cd01ffa9dd0a22d00e09a156 fixed the findlib installation of bytecode version of the GUI, but some files (*.o to be precise) were still missing. This patch installs the same set of files in install-findlib and install-(opt,byte) for `VIEWER` and `DGRAPH`
