### PR TITLE
[Configure] ocamlfind use printconf instead of query

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -146,11 +146,13 @@ AC_CHECK_PROG(OCAMLFIND,ocamlfind,ocamlfind)
 if test "$OCAMLFIND" = "" ; then
    echo "No ocamlfind detected"
 else
-   OCAMLLIB_BY_FINDLIB=`ocamlfind query stdlib | tr -d '\\r'`
+   OCAMLLIB_BY_FINDLIB=`ocamlfind printconf stdlib | tr -d '\\r'`
    if test "$OCAMLLIB_BY_FINDLIB" = "$OCAMLLIB" ; then
       echo "OCamlfind detected and enabled"
    else
-      echo "OCamlfind detected but disabled. Standard libraries differ."
+      echo "OCamlfind detected but disabled. Standard libraries differ:"
+      echo "  ocamlc: '$OCAMLLIB'"
+      echo "  ocamlfind: '$OCAMLLIB_BY_FINDLIB'"
       OCAMLFIND=""
    fi
 fi


### PR DESCRIPTION
The path can have slash in one case and backslash in the other case.
ocamlfind printconf stdlib should be the same than ocamlc -where.
