### PR TITLE
Use 97 as default size when creating hash tables

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+ o functions in modules Components, Dominator, Flow, Topological and Traverse
+   now create smaller auxiliary hash tables
  o Graphviz: add the attribute `HtmlLabel to specify html strings.
 
 version 1.8.5, March 4, 2014

--- a/src/builder.ml
+++ b/src/builder.ml
@@ -45,7 +45,7 @@ end
 
 module I(G : Sig.I) = struct
   module G = G
-  let empty () = G.create ~size:997 ()
+  let empty () = G.create ~size:97 ()
   let copy = G.copy
   let add_vertex g v = G.add_vertex g v; g
   let add_edge g v1 v2 = G.add_edge g v1 v2; g

--- a/src/components.ml
+++ b/src/components.ml
@@ -29,8 +29,8 @@ module Make(G: G) = struct
   module H = Hashtbl.Make(G.V)
 
   let scc g =
-    let root = H.create 997 in
-    let hashcomp = H.create 997 in
+    let root = H.create 97 in
+    let hashcomp = H.create 97 in
     let stack = ref [] in
     let numdfs = ref 0 in
     let numcomp = ref 0 in

--- a/src/dominator.ml
+++ b/src/dominator.ml
@@ -249,7 +249,7 @@ struct
   *)
   let dominators_to_dom_tree cfg ?(pred=G.pred) dominators =
     let idoms = dominators_to_idoms dominators in
-    let tree = H.create 9999 in
+    let tree = H.create 97 in
     let () =
       G.iter_vertex
 	(fun y ->

--- a/src/flow.ml
+++ b/src/flow.ml
@@ -46,9 +46,9 @@ struct
   module Se = Set.Make(G.E)
   module Sv = Set.Make(G.V)
 
-  let excedents = V.create 997
-  let hauteur = V.create 997
-  let flot = E.create 997
+  let excedents = V.create 97
+  let hauteur = V.create 97
+  let flot = E.create 97
 
   let fold_booleen f = List.fold_left (fun r x->(f x) || r) false
 
@@ -196,7 +196,7 @@ struct
     module H = Hashtbl.Make(G.V)
     type mark = Plus | Minus
 
-    let marked = H.create 997
+    let marked = H.create 97
     let unvisited = Queue.create ()
 
     let clear () = H.clear marked
@@ -227,7 +227,7 @@ struct
 	   let hash e = U.hash (E.src e, E.dst e)
 	 end)
 
-    let create () = H.create 997
+    let create () = H.create 97
 
     let find = H.find
 

--- a/src/topological.ml
+++ b/src/topological.ml
@@ -132,7 +132,7 @@ struct
 
   let fold f g acc =
     let checker = C.create g in
-    let degree = H.create 997 in
+    let degree = H.create 97 in
     let todo = Q.create () in
     let push x =
       H.remove degree x;

--- a/src/traverse.ml
+++ b/src/traverse.ml
@@ -32,7 +32,7 @@ module Dfs(G : G) = struct
   module H = Hashtbl.Make(G.V)
 
   let iter ?(pre=fun _ -> ()) ?(post=fun _ -> ()) g =
-    let h = H.create 65537 in
+    let h = H.create 97 in
     let rec visit v =
       if not (H.mem h v) then begin
 	H.add h v ();
@@ -46,7 +46,7 @@ module Dfs(G : G) = struct
   let postfix post g = iter ~post g
 
   let iter_component ?(pre=fun _ -> ()) ?(post=fun _ -> ()) g v =
-    let h = H.create 65537 in
+    let h = H.create 97 in
     let rec visit v =
       H.add h v ();
       pre v;
@@ -62,7 +62,7 @@ module Dfs(G : G) = struct
      already visited in the current component; [h v = false] means
      already visited in another tree *)
   let has_cycle g =
-    let h = H.create 65537 in
+    let h = H.create 97 in
     let rec visit v =
       H.add h v true;
       G.iter_succ
@@ -74,8 +74,8 @@ module Dfs(G : G) = struct
     with Exit -> true
 
   let has_cycle_undirected g =
-    let h = H.create 65537 in
-    let father = H.create 65537 in
+    let h = H.create 97 in
+    let father = H.create 97 in
     let is_father u v = (* u is the father of v in the DFS descent *)
       try G.V.equal (H.find father v) u with Not_found -> false
     in
@@ -98,7 +98,7 @@ module Dfs(G : G) = struct
   module Tail = struct
 
     let has_cycle g =
-      let h = H.create 65537 in
+      let h = H.create 97 in
       let stack = Stack.create () in
       let loop () =
 	while not (Stack.is_empty stack) do
@@ -129,8 +129,8 @@ module Dfs(G : G) = struct
 	true
 
     let has_cycle_undirected g =
-      let h = H.create 65537 in
-      let father = H.create 65537 in
+      let h = H.create 97 in
+      let father = H.create 97 in
       let is_father u v = (* u is the father of v in the DFS descent *)
 	try G.V.equal (H.find father v) u with Not_found -> false
       in
@@ -168,7 +168,7 @@ module Dfs(G : G) = struct
       if G.is_directed then has_cycle g else has_cycle_undirected g
 
     let iter f g =
-      let h = H.create 65537 in
+      let h = H.create 97 in
       let stack = Stack.create () in
       let loop () =
 	while not (Stack.is_empty stack) do
@@ -187,7 +187,7 @@ module Dfs(G : G) = struct
 	g
 
     let iter_component f g v0 =
-      let h = H.create 65537 in
+      let h = H.create 97 in
       let stack = Stack.create () in
       Stack.push v0 stack;
       while not (Stack.is_empty stack) do
@@ -239,7 +239,7 @@ module Bfs(G : G) = struct
   module H = Hashtbl.Make(G.V)
 
   let iter f g =
-    let h = H.create 65537 in
+    let h = H.create 97 in
     let q = Queue.create () in
     (* invariant: [h] contains exactly the vertices which have been pushed *)
     let push v =
@@ -255,7 +255,7 @@ module Bfs(G : G) = struct
     G.iter_vertex (fun v -> push v; loop ()) g
 
   let iter_component f g v0 =
-    let h = H.create 65537 in
+    let h = H.create 97 in
     let q = Queue.create () in
     (* invariant: [h] contains exactly the vertices which have been pushed *)
     let push v =


### PR DESCRIPTION
- avoid putting too much pressure on OCaml's gc
- Fixes #14
