### PR TITLE
Add an opam file

### DIFF
--- a/opam
+++ b/opam
@@ -1,0 +1,32 @@
+opam-version: "1"
+maintainer: "filliatr@lri.fr"
+authors: [
+  "Sylvain Conchon"
+  "Jean-Christophe Filliâtre"
+  "Julien Signoles"
+]
+homepage: "http://ocamlgraph.lri.fr/"
+license: "GNU Library General Public License version 2.1"
+doc: ["http://ocamlgraph.lri.fr/doc"]
+tags: [
+  "graph"
+  "library"
+  "algorithms"
+  "directed graph"
+  "vertice"
+  "edge"
+  "persistent"
+  "imperative"
+]
+build: [
+  ["autoconf"]
+  ["./configure"]
+  [make]
+  [make "install-findlib"]
+]
+remove: [["ocamlfind" "remove" "ocamlgraph"]]
+depends: ["ocamlfind"]
+depopts: [
+  "lablgtk"
+  "conf-gnomecanvas"
+]


### PR DESCRIPTION
Because of autoconf, the dev repository is not pinnable in opam. This opam file (which is directly copied from the opam repository) fixes this.
