### PR TITLE
[path] generalize WEIGHT signature

### DIFF
--- a/src/pack.ml
+++ b/src/pack.ml
@@ -43,9 +43,9 @@ struct
   module Components = Components.Make(G)
 
   module W = struct
-    type label = int
+    type edge = G.E.t
     type t = int
-    let weight x = x
+    let weight e = G.E.label e
     let zero = 0
     let add = (+)
     let compare : t -> t -> int = Pervasives.compare

--- a/src/path.ml
+++ b/src/path.ml
@@ -18,9 +18,9 @@
 (* $Id: path.ml,v 1.6 2005-07-18 07:10:35 filliatr Exp $ *)
 
 module type WEIGHT = sig
-  type label
+  type edge
   type t
-  val weight : label -> t
+  val weight : edge -> t
   val compare : t -> t -> int
   val add : t -> t -> t
   val zero : t
@@ -45,7 +45,7 @@ end
 
 module Dijkstra
   (G: G)
-  (W: WEIGHT with type label = G.E.label) =
+  (W: WEIGHT with type edge = G.E.t) =
 struct
 
   open G.E
@@ -80,7 +80,7 @@ struct
             (fun e ->
                let ev = dst e in
                if not (H.mem visited ev) then begin
-                 let dev = W.add w (W.weight (label e)) in
+                 let dev = W.add w (W.weight e) in
                  let improvement =
                    try W.compare dev (H.find dist ev) < 0 with Not_found -> true
                  in
@@ -104,7 +104,7 @@ end
 
 module BellmanFord
   (G: G)
-  (W: WEIGHT with type label = G.E.label) =
+  (W: WEIGHT with type edge = G.E.t) =
 struct
 
   open G.E
@@ -145,7 +145,7 @@ struct
           let ev2 = dst e in
           try begin
             let dev1 = H.find dist ev1 in
-            let dev2 = W.add dev1 (W.weight (label e)) in
+            let dev2 = W.add dev1 (W.weight e) in
             let improvement =
               try W.compare dev2 (H.find dist ev2) < 0
               with Not_found -> true

--- a/src/path.mli
+++ b/src/path.mli
@@ -40,11 +40,11 @@ end
 
 (** Signature for edges' weights. *)
 module type WEIGHT = sig
-  type label
-    (** Type for labels of graph edges. *)
+  type edge
+    (** Type for graph edges. *)
   type t
     (** Type of edges' weights. *)
-  val weight : label -> t
+  val weight : edge -> t
     (** Get the weight of an edge. *)
   val compare : t -> t -> int
     (** Weights must be ordered. *)
@@ -56,7 +56,7 @@ end
 
 module Dijkstra
   (G: G)
-  (W: WEIGHT with type label = G.E.label) :
+  (W: WEIGHT with type edge = G.E.t) :
 sig
 
   val shortest_path : G.t -> G.V.t -> G.V.t -> G.E.t list * W.t
@@ -73,7 +73,7 @@ end
 
 module BellmanFord
   (G: G)
-  (W: WEIGHT with type label = G.E.label) :
+  (W: WEIGHT with type edge = G.E.t) :
 sig
 
   module H : Hashtbl.S with type key = G.V.t

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -71,9 +71,9 @@ let gc = G.add_edge_e g (G.E.create 5 10 1)
 let gc = G.add_vertex gc 6
 
 module W = struct 
-  type label = int
+  type edge = G.E.t
   type t = int
-  let weight x = x 
+  let weight e = G.E. label e
   let zero = 0
   let add = (+)
   let compare = compare


### PR DESCRIPTION
I generalized the `Path.WEIGHT` signature slightly by changing the type of `weight` from `lable -> t` to `edge -> t`. This allows meaningful weights even when using graphs with `()` edge labels. Also see #20.

Note that the changes are marginal, and note that every call to the weight function in the library had the form `weight (G.E.label e)` anyways, which now simplifies to `weight e`.
