### PR TITLE
Clique module

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -72,7 +72,7 @@ CMO = 	version util blocks persistent imperative \
 	components path nonnegative traverse coloring topological kruskal flow \
         prim dominator graphviz gml dot_parser dot_lexer dot pack \
 	gmap minsep cliquetree mcs_m md strat fixpoint leaderlist contraction \
-	graphml merge mincut
+	graphml merge mincut clique
 CMO := $(LIB) $(patsubst %, $(SRCDIR)/%.cmo, $(CMO))
 
 CMX = $(CMO:.cmo=.cmx)

--- a/src/clique.ml
+++ b/src/clique.ml
@@ -1,0 +1,48 @@
+(**************************************************************************)
+(* 									  *)
+(* Ocamlgraph: a generic graph library for OCaml 			  *)
+(* Copyright (C) 2014-2015 						  *)
+(* Giselle Reis 							  *)
+(* 									  *)
+(* This software is free software; you can redistribute it and/or 	  *)
+(* modify it under the terms of the GNU Library General Public 		  *)
+(* License version 2.1, with the special exception on linking 		  *)
+(* described in file LICENSE. 						  *)
+(* 									  *)
+(* This software is distributed in the hope that it will be useful, 	  *)
+(* but WITHOUT ANY WARRANTY; without even the implied warranty of 	  *)
+(* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 		  *)
+(* 									  *)
+(**************************************************************************)
+
+module type G = sig
+  type t
+  module V : Sig.COMPARABLE
+  val succ : t -> V.t -> V.t list
+  val fold_vertex : (V.t -> 'a -> 'a) -> t -> 'a -> 'a
+end
+
+module Bron_Kerbosch(G : G) = struct
+
+  let rec bron_kerbosch cliquelst graph clique candidates used = match (candidates, used) with
+    | ([], []) -> clique :: cliquelst
+    | ([], _) -> cliquelst
+    | (c, u) -> 
+      let (_, _, cliques) = List.fold_left ( fun (c, u, acc) v ->
+	(* Get the neighbors ignoring self-loops *)
+	let n = List.filter (fun nb -> not (G.V.equal nb v)) (G.succ graph v) in
+	let c' = List.filter (fun cv -> List.exists (fun v -> G.V.equal v cv) n) c in
+	let u' = List.filter (fun cv -> List.exists (fun v -> G.V.equal v cv) n) u in
+	let c_minus_v = List.filter (fun cv -> not (G.V.equal cv v)) c in
+	
+	( c_minus_v, (v :: u), bron_kerbosch acc graph (v :: clique) c' u')
+      ) (c, u, []) c in 
+      cliques @ cliquelst
+  
+  let maximalcliques g = 
+    let vertices = G.fold_vertex (fun v acc -> v :: acc) g [] in
+    bron_kerbosch [] g [] vertices []
+
+end
+
+

--- a/src/clique.mli
+++ b/src/clique.mli
@@ -1,0 +1,40 @@
+(**************************************************************************)
+(* 									  *)
+(* Ocamlgraph: a generic graph library for OCaml 			  *)
+(* Copyright (C) 2014-2015 						  *)
+(* Giselle Reis 							  *)
+(* 									  *)
+(* This software is free software; you can redistribute it and/or 	  *)
+(* modify it under the terms of the GNU Library General Public 		  *)
+(* License version 2.1, with the special exception on linking 		  *)
+(* described in file LICENSE. 						  *)
+(* 									  *)
+(* This software is distributed in the hope that it will be useful, 	  *)
+(* but WITHOUT ANY WARRANTY; without even the implied warranty of 	  *)
+(* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 		  *)
+(* 									  *)
+(**************************************************************************)
+
+(** Graph cliques *)
+
+(** {1 Clique algorithms} *)
+
+(** {2 Bron-Kerbosch Algorithm}
+
+  This algorithm will find and return all maximal cliques in an undirected graph. *)
+
+(** Minimal graph signature for Bron-Kerbosch.
+    Sub-signature of {!Sig.G}. *)
+module type G = sig
+  type t
+  module V : Sig.COMPARABLE
+  val succ : t -> V.t -> V.t list
+  val fold_vertex : (V.t -> 'a -> 'a) -> t -> 'a -> 'a
+end
+
+module Bron_Kerbosch(G : G) : sig
+  val maximalcliques : G.t -> G.V.t list list
+  (** [maximalcliques g] computes all the maximal cliques of [g] using the
+      Bron-Kerbosch algorithm. It returns the sets of vertices belonging to the
+      same maximal clique. *)
+end

--- a/tests/test_clique.ml
+++ b/tests/test_clique.ml
@@ -1,0 +1,29 @@
+(* Test file for Brom-Kerbosch *)
+
+open Graph
+
+module G = Persistent.Graph.Concrete (struct 
+  type t = int 
+  let compare = compare
+  let hash = Hashtbl.hash
+  let equal = (=)
+end)
+
+module BK = Clique.Bron_Kerbosch(G)
+
+let () = 
+  let vertices = [1;2;3;4;5;6;7] in
+  let edges = [(1,2);(1,5);(2,5);(2,3);(4,5);(3,4);(4,6)] in
+  let g = List.fold_left (fun graph v -> G.add_vertex graph v) G.empty vertices in
+  let g = List.fold_left (fun graph (v1, v2) -> G.add_edge graph v1 v2) g edges in
+  let cliques = BK.maximalcliques g in
+  (* The cliques of this graph should be: [2, 3], [3, 4], [1, 2, 5], [4, 5], [4, 6], [7] *)
+  assert (List.length cliques == 6);
+  assert (List.exists (fun cl -> List.length cl == 2 && List.mem 2 cl && List.mem 3 cl) cliques);
+  assert (List.exists (fun cl -> List.length cl == 2 && List.mem 3 cl && List.mem 4 cl) cliques);
+  assert (List.exists (fun cl -> List.length cl == 3 && List.mem 1 cl && List.mem 2 cl && List.mem 5 cl) cliques);
+  assert (List.exists (fun cl -> List.length cl == 2 && List.mem 4 cl && List.mem 5 cl) cliques);
+  assert (List.exists (fun cl -> List.length cl == 2 && List.mem 4 cl && List.mem 6 cl) cliques);
+  assert (List.exists (fun cl -> List.length cl == 1 && List.mem 7 cl) cliques);
+;;
+


### PR DESCRIPTION
Hi,

the patches add a clique module to ocamlgraph which contains the implementation of the Bron-Kerbosch algorithm for finding maximal cliques. It returns a list of cliques, which are just a list of vertices belonging to the same clique. There is also a second patch with a file for testing the implementation.

Let me know if there is something not in accordance with your implementation that I can change.

Thank you!

Best,
Giselle