### PR TITLE
Prevents Fixpoint from catching external Not_found

### DIFF
--- a/src/fixpoint.ml
+++ b/src/fixpoint.ml
@@ -112,9 +112,9 @@ struct
 
       (* get some node from the node-set -- this will eventually trigger
            an exception *)
-      match N.choose wl with
-      | exception Not_found -> data
-      | n ->
+      match (try Some (N.choose wl) with Not_found -> None) with
+      | None -> data
+      | Some n ->
         (* remove the chosen node from the set *)
         let wl = N.remove n wl in
 

--- a/src/fixpoint.ml
+++ b/src/fixpoint.ml
@@ -110,10 +110,11 @@ struct
           | Some d' -> (d', N.add n wl)
       in
 
-      try
-        (* get some node from the node-set -- this will eventually trigger
+      (* get some node from the node-set -- this will eventually trigger
            an exception *)
-        let n = N.choose wl in
+      match N.choose wl with
+      | exception Not_found -> data
+      | n ->
         (* remove the chosen node from the set *)
         let wl = N.remove n wl in
 
@@ -165,8 +166,6 @@ struct
         (* do a recursive call: the recursion will eventually end with a
          * Not_found exception when no nodes are left in the work list *)
         worklist data wl
-
-      with Not_found -> data
     in
     let data = worklist data nodes in
     (fun n -> M.find n data)


### PR DESCRIPTION
Fixpoint used to work on a wait_list, using Map.choose on this wait
list, and catching Not_found to know when the computation was
finished. However, the while algorithm was in the try block, thus it
also catched Not_found exceptions raised by this computation - in
particular potential exceptions raised by user-defined functions (given
as functor parameters). This commit ensures that only the M.choose
Not_found can be catched.