### PR TITLE
Adds weak topological ordering for fixpoint computation

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,10 @@
 
 * marks some incompatible change
 
+ o new functors [WeakTopological] and [ChaoticIteration] to compute
+   fixpoints with widening, following Bourdoncle's algorithms (contributed
+   by Thibault Suzanne)
+
 version 1.8.7, April 12, 2016
 -----------------------------
  o fixed examples/demo.ml so that it also compiles with an installed OCamlGraph

--- a/Makefile.in
+++ b/Makefile.in
@@ -67,12 +67,12 @@ endif
 LIB= unionfind heap bitv
 LIB:=$(patsubst %, $(LIBDIR)/%.cmo, $(LIB))
 
-CMO = 	version util blocks persistent imperative \
+CMO =	version util blocks persistent imperative \
 	delaunay builder classic rand oper \
 	components path nonnegative traverse coloring topological kruskal flow \
-        prim dominator graphviz gml dot_parser dot_lexer dot pack \
+	prim dominator graphviz gml dot_parser dot_lexer dot pack \
 	gmap minsep cliquetree mcs_m md strat fixpoint leaderlist contraction \
-	graphml merge mincut clique
+	graphml merge mincut clique weakTopological
 CMO := $(LIB) $(patsubst %, $(SRCDIR)/%.cmo, $(CMO))
 
 CMX = $(CMO:.cmo=.cmx)
@@ -432,9 +432,9 @@ ifeq (@LABLGNOMECANVAS@,yes)
 		graph$(OBJEXT) graph$(LIBEXT) graph.cmx graph.cmo graph.cmi \
 		$(CMA) $(CMXA) \
 		$(VIEWER_CMXLIB) $(VIEWER_CMOLIB) $(VIEWER_CMILIB) \
-                $(VIEWER_CMXLIB:.cmx=.o) \
-                $(DGRAPH_CMXLIB) $(DGRAPH_CMOLIB) $(DGRAPH_CMILIB) \
-                $(DGRAPH_CMXLIB:.cmx=.o)
+		$(VIEWER_CMXLIB:.cmx=.o) \
+		$(DGRAPH_CMXLIB) $(DGRAPH_CMOLIB) $(DGRAPH_CMILIB) \
+		$(DGRAPH_CMXLIB:.cmx=.o)
 else
 	$(OCAMLFIND) install $(OCAMLFINDDEST) ocamlgraph META \
 		$(SRCDIR)/*.mli $(VIEWER_DIR)/*.mli $(DGRAPH_DIR)/*.mli \
@@ -486,7 +486,7 @@ headers:
 	   $(SRCDIR)/*.ml $(SRCDIR)/*.ml[ily] \
 	   $(ED_DIR)/*.ml $(ED_DIR)/*.mli
 	headache \
-           -c misc/headache_config.txt \
+	   -c misc/headache_config.txt \
 	   -h $(DGRAPH_DIR)/headers/CEA_LGPL \
 	   $(DGRAPH_DIR)/*.ml $(DGRAPH_DIR)/*.mli
 # export
@@ -500,7 +500,7 @@ WWW = /users/www-perso/projets/ocamlgraph
 
 FILES = src/*.ml* lib/*.ml* Makefile.in configure configure.in META.in  \
 	.depend editor/ed_*.ml* editor/Makefile \
-        editor/tests/*.dot editor/tests/*.gml \
+	editor/tests/*.dot editor/tests/*.gml \
 	view_graph/*.ml view_graph/*.mli \
 	view_graph/README view_graph/Makefile \
 	dgraph/*.ml dgraph/*.mli \
@@ -593,7 +593,7 @@ tags:
 	      "--regex=/let[ \t]+rec[ \t]+\([^ \t]+\)/\1/" \
 	      "--regex=/and[ \t]+\([^ \t]+\)/\1/" \
 	      "--regex=/type[ \t]+\([^ \t]+\)/\1/" \
-              "--regex=/exception[ \t]+\([^ \t]+\)/\1/" \
+	      "--regex=/exception[ \t]+\([^ \t]+\)/\1/" \
 	      "--regex=/val[ \t]+\([^ \t]+\)/\1/" \
 	      "--regex=/module[ \t]+\([^ \t]+\)/\1/"
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -72,7 +72,7 @@ CMO =	version util blocks persistent imperative \
 	components path nonnegative traverse coloring topological kruskal flow \
 	prim dominator graphviz gml dot_parser dot_lexer dot pack \
 	gmap minsep cliquetree mcs_m md strat fixpoint leaderlist contraction \
-	graphml merge mincut clique weakTopological
+	graphml merge mincut clique weakTopological chaoticIteration
 CMO := $(LIB) $(patsubst %, $(SRCDIR)/%.cmo, $(CMO))
 
 CMX = $(CMO:.cmo=.cmx)

--- a/Makefile.in
+++ b/Makefile.in
@@ -458,12 +458,14 @@ DOC_SRC	= $(CMI:.cmi=.mli) $(DOC_CMO:.cmo=.mli) $(DOC_CMO:.cmo=.ml)
 ifeq (@LABLGNOMECANVAS@,yes)
 DOC_SRC := $(DOC_SRC) $(DGRAPH_CMI:.cmi=.mli)
 endif
+DOC_CHARSET = utf-8
 
 .PHONY: doc
 doc: $(DOC_CMO)
 	mkdir -p doc
 	rm -f doc/*
-	$(OCAMLDOC) -d doc -html $(DGRAPH_INCLUDES) -I lib -I src $(DOC_SRC)
+	$(OCAMLDOC) -charset $(DOC_CHARSET) -d doc -html $(DGRAPH_INCLUDES) \
+		-I lib -I src $(DOC_SRC)
 
 # literate programming
 $(NAME).tex: $(DOC_SRC)

--- a/src/chaoticIteration.ml
+++ b/src/chaoticIteration.ml
@@ -1,0 +1,135 @@
+(**************************************************************************)
+(*                                                                        *)
+(*  Ocamlgraph: a generic graph library for OCaml                         *)
+(*  Copyright (C) 2004-2010                                               *)
+(*  Sylvain Conchon, Jean-Christophe Filliatre and Julien Signoles        *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU Library General Public           *)
+(*  License version 2.1, with the special exception on linking            *)
+(*  described in file LICENSE.                                            *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Copyright © 2015 Thibault Suzanne <thi.suzanne (@) gmail.com>
+ * École Normale Supérieure, Département d'Informatique
+ * Paris Sciences et Lettres
+*)
+
+(* Original algorithm by François Bourdoncle. See :
+ * "Efficient chaotic iteration strategies with widenings",
+ * Formal Methods in Programming and their Applications,
+ * Springer Berlin Heidelberg, 1993.
+*)
+
+let ( |> ) x f = f x
+
+type 'a widening_set =
+  | FromWto
+  | Predicate of ('a -> bool)
+
+module type G = sig
+  type t
+
+  module V : Sig.COMPARABLE
+
+  module E : sig
+    type t
+    val src : t -> V.t
+  end
+
+  val fold_pred_e : (E.t -> 'a -> 'a) -> t -> V.t -> 'a -> 'a
+end
+
+module type Data = sig
+  type t
+
+  type edge
+
+  val join : t -> t -> t
+  val equal : t -> t -> bool
+
+  val analyze : edge -> t -> t
+
+  val widening : t -> t -> t
+end
+
+module Make
+    (G : G)
+    (D : Data with type edge = G.E.t)
+=
+struct
+  module M = Map.Make (G.V)
+
+  let recurse g wto init widening_set widening_delay =
+
+    (* The following two functions are predicates used to know whether
+       to compute a widening when analysing a vertex which is not
+       (resp. is) the head of a WTO component. They will be called
+       only if the specified number of steps before widening has been
+       done. *)
+    let do_nonhead_widen v = match widening_set with
+      | FromWto -> false
+      | Predicate f -> f v
+    in
+
+    let do_head_widen v = match widening_set with
+      | FromWto -> true
+      | Predicate f -> f v
+    in
+
+    let find vertex data =
+      try M.find vertex data
+      with Not_found -> init vertex
+    in
+
+    let analyze_vertex widening_steps do_widen v data =
+      (* Computes the result of the analysis for one vertex *)
+      let result = G.fold_pred_e
+          (fun edge acc ->
+             let src = G.E.src edge in
+             let data_src = find src data in
+             let data_dst = D.analyze edge data_src in
+             D.join data_dst acc)
+          g v (init v) in
+      if widening_steps <= 0 && do_widen v
+      then D.widening (find v data) result
+      else result
+    in
+
+    let rec analyze_elements widening_steps comp data =
+      (* Computes the result of one iteration of the analysis of the
+         elements of a component. *)
+      WeakTopological.fold_left (analyze_element widening_steps) data comp
+
+    and stabilize can_stop widening_steps head comps data =
+      (* Iterates the analysis of a component until
+         stabilisation. [can_stop] is [false] if no iteration has been
+         made so far, since at least one is needed before ending with
+         stabilisation. *)
+      let old_data_head =
+        find head data in
+      let new_data_head =
+        analyze_vertex widening_steps do_head_widen head data in
+      if can_stop && D.equal old_data_head new_data_head
+      then data
+      else
+        data
+        |> M.add head new_data_head
+        |> analyze_elements widening_steps comps
+        |> stabilize true (widening_steps - 1) head comps
+
+    and analyze_element widening_steps data = function
+      (* Computes the result of the analysis of one element *)
+      | WeakTopological.Vertex v ->
+        M.add v (analyze_vertex widening_steps do_nonhead_widen v data) data
+      | WeakTopological.Component (head, comps) ->
+        stabilize false widening_delay head comps data
+    in
+
+    analyze_elements widening_delay wto M.empty
+end

--- a/src/chaoticIteration.mli
+++ b/src/chaoticIteration.mli
@@ -1,0 +1,164 @@
+(**************************************************************************)
+(*                                                                        *)
+(*  Ocamlgraph: a generic graph library for OCaml                         *)
+(*  Copyright (C) 2004-2010                                               *)
+(*  Sylvain Conchon, Jean-Christophe Filliatre and Julien Signoles        *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU Library General Public           *)
+(*  License version 2.1, with the special exception on linking            *)
+(*  described in file LICENSE.                                            *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Copyright © 2015 Thibault Suzanne <thi.suzanne (@) gmail.com>
+ * École Normale Supérieure, Département d'Informatique
+ * Paris Sciences et Lettres
+*)
+
+(** Fixpoint computation with widenings using weak topological
+    orderings as defined by François Bourdoncle and implemented
+    in {!WeakTopological}.
+
+    {!Fixpoint} is another (simpler) fixpoint computation module, with
+    general references.
+
+    The general idea of fixpoint computation is to iteratively compute
+    the result of the analysis a vertex from the results of its
+    predecessors, until stabilisation is achieved on every vertex. The
+    way to determine, at each step, the next vertex to analyse is
+    called a {e chaotic iteration strategy}. A good strategy can make
+    the analysis much faster. To enforce the termination of the
+    analyse and speed it up when it terminates in too many steps, one
+    can also use a {e widening}, to ensure that there is no infinite
+    (nor too big) sequence of intermediary results for a given
+    vertex. However, it usually results in a loss of precision, which
+    is why choosing a good widening set (the set of points on which
+    the widening will be performed) is mandatory.
+
+    This module computes a fixpoint over a graph using weak
+    topological ordering, which can be used to get both the iteration
+    strategy and the widening set. The module {!WeakTopological} aims
+    to compute weak topological orderings which are known to be
+    excellent decompositions w.r.t these two critical points.
+
+    @author Thibault Suzanne
+
+    @see "Efficient chaotic iteration strategies with widenings",
+    François Bourdoncle,
+    Formal Methods in Programming and their Applications,
+    Springer Berlin Heidelberg, 1993
+
+*)
+
+
+(** How to determine which vertices are to be considered as widening
+    points.
+
+    - [FromWto] indicates to use as widening points the heads of the
+      weak topological ordering given as a parameter of the analysis
+      function. This will always be a safe choice, and in most cases
+      it will also be a good one with respect to the precision of the
+      analysis.
+
+    - [Predicate f] indicates to use [f] as the characteristic
+      function of the widening set. [Predicate (fun _ -> false)] can
+      be used if a widening is not needed. This variant can be used
+      when there is a special knowledge of the graph to achieve
+      a better precision of the analysis. For instance, if the graph
+      happens to be the flow graph of a program, the predicate should
+      be true for control structures heads. In any case, a condition
+      for a safe widening predicate is that every cycle of the graph
+      should go through at least one widening point. Otherwise, the
+      analysis may not terminate. Note that even with a safe
+      predicate, ensuring the termination does still require a correct
+      widening definition.
+*)
+type 'a widening_set =
+  | FromWto
+  | Predicate of ('a -> bool)
+
+(** Minimal graph signature for the algorithm.
+    Sub-signature of [Traverse.G]. *)
+module type G = sig
+  type t
+
+  module V : Sig.COMPARABLE
+
+  module E : sig
+    type t
+    val src : t -> V.t
+  end
+
+  val fold_pred_e : (E.t -> 'a -> 'a) -> t -> V.t -> 'a -> 'a
+end
+
+(** Parameters of the analysis. *)
+module type Data = sig
+  type t
+  (** Information stored at each vertex. *)
+
+  type edge
+  (** Edge of the graph. *)
+
+  val join : t -> t -> t
+  (** Operation to join data when several paths meet. *)
+
+  val equal : t -> t -> bool
+  (** Equality test for data. *)
+
+  val analyze : edge -> t -> t
+  (** How to analyze one edge: given an edge and the data stored at
+      its origin, it must compute the resulting data to be stored at
+      its destination. *)
+
+  val widening : t -> t -> t
+  (** The widening operator. [fun _ x -> x] is correct and is
+      equivalent to not doing widening. Note that to enforce
+      termination, the following property should hold: for all
+      sequence [x_0, x_1, ...] of data, the sequence defined by [y_0 =
+      x_0; y_{i+1} = widening y_i x_i] stabilizes in finite time. *)
+end
+
+module Make
+    (G : G)
+    (D : Data with type edge = G.E.t) :
+sig
+  module M : Map.S with type key = G.V.t
+  (** Map used to store the result of the analysis *)
+
+  val recurse :
+    G.t ->
+    G.V.t WeakTopological.t ->
+    (G.V.t -> D.t) ->
+    G.V.t widening_set ->
+    int ->
+    D.t M.t
+    (** [recurse g wto init widening_set widening_delay] computes the
+        fixpoint of the analysis of a graph. This function uses the
+        recursive iteration strategy: it recursively stabilizes the
+        subcomponents of every component every time the component is
+        stabilized (cf. Bourdoncle's paper).
+
+        @param g The graph to analyse.
+
+        @param wto A weak topological ordering of the vertices of [g].
+
+        @param widening_set On which points to do the widening.
+
+        @param widening_delay How many computations steps will be done
+        before using widening to speed up the stabilisation. This
+        counter is reset when entering each component, and is shared
+        between all outermost vertices of this component. A negative
+        value means [0].
+
+        @param init How to compute the initial analysis data.
+
+        @return A map from vertices of [g] to their analysis result.
+
+    *)
+end

--- a/src/weakTopological.ml
+++ b/src/weakTopological.ml
@@ -1,0 +1,103 @@
+(**************************************************************************)
+(*                                                                        *)
+(*  Ocamlgraph: a generic graph library for OCaml                         *)
+(*  Copyright (C) 2004-2010                                               *)
+(*  Sylvain Conchon, Jean-Christophe Filliatre and Julien Signoles        *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU Library General Public           *)
+(*  License version 2.1, with the special exception on linking            *)
+(*  described in file LICENSE.                                            *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Copyright © 2015 Thibault Suzanne <thi.suzanne (@) gmail.com>
+ * École Normale Supérieure, Département d'Informatique
+ * Paris Sciences et Lettres
+*)
+
+(* Original algorithm by François Bourdoncle. See :
+ * "Efficient chaotic iteration strategies with widenings",
+ * Formal Methods in Programming and their Applications,
+ * Springer Berlin Heidelberg, 1993.
+*)
+
+module type G = sig
+  type t
+  module V : Sig.COMPARABLE
+  val iter_vertex : (V.t -> unit) -> t -> unit
+  val iter_succ : (V.t -> unit) -> t -> V.t -> unit
+end
+
+type 'a element =
+  | Vertex of 'a
+  | Component of 'a * 'a t
+
+and 'a t = 'a element list
+
+let fold_left = List.fold_left
+
+module Make (G : G) = struct
+
+  let recursive_scc g root_g =
+    (* Straight OCaml implementation of the Section 4.3,
+       fig. 4 algorithm in Bourdoncle's paper *)
+    let stack = Stack.create () in
+    let dfn = Hashtbl.create 1024 in
+    let num = ref 0 in
+    let partition = ref [] in
+
+    G.iter_vertex (fun v -> Hashtbl.add dfn v 0) g;
+
+    let rec visit vertex partition =
+      let head = ref 0 in
+      let loop = ref false in
+      Stack.push vertex stack;
+      incr num;
+      Hashtbl.replace dfn vertex !num;
+      head := !num;
+      G.iter_succ
+        (fun succ ->
+           let dfn_succ = Hashtbl.find dfn succ in
+           let min =
+             if dfn_succ = 0
+             then visit succ partition
+             else dfn_succ in
+           if min <= !head then begin
+             head := min;
+             loop := true
+           end)
+        g vertex;
+      if !head = Hashtbl.find dfn vertex
+      then begin
+        Hashtbl.replace dfn vertex max_int;
+        let element = ref (Stack.pop stack) in
+        if !loop then begin
+          while G.V.compare !element vertex <> 0 do
+            Hashtbl.replace dfn !element 0;
+            element := Stack.pop stack;
+          done;
+          partition := component vertex :: !partition;
+        end
+        else partition := Vertex vertex :: !partition
+      end;
+      !head
+
+    and component vertex =
+      let partition = ref [] in
+      G.iter_succ
+        (fun succ ->
+           if Hashtbl.find dfn succ = 0
+           then ignore (visit succ partition : int))
+        g vertex;
+      Component (vertex, !partition)
+
+    in
+    let (_ : int) = visit root_g partition in
+    !partition
+
+end

--- a/src/weakTopological.mli
+++ b/src/weakTopological.mli
@@ -1,0 +1,111 @@
+(**************************************************************************)
+(*                                                                        *)
+(*  Ocamlgraph: a generic graph library for OCaml                         *)
+(*  Copyright (C) 2004-2010                                               *)
+(*  Sylvain Conchon, Jean-Christophe Filliatre and Julien Signoles        *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU Library General Public           *)
+(*  License version 2.1, with the special exception on linking            *)
+(*  described in file LICENSE.                                            *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(**************************************************************************)
+
+(* Copyright © 2015 Thibault Suzanne <thi.suzanne (@) gmail.com>
+ * École Normale Supérieure, Département d'Informatique
+ * Paris Sciences et Lettres
+*)
+
+(* Original algorithm by François Bourdoncle. See :
+ * "Efficient chaotic iteration strategies with widenings",
+ * Formal Methods in Programming and their Applications,
+ * Springer Berlin Heidelberg, 1993.
+*)
+
+(** Weak topological ordering of the vertices of a graph, as described
+    by François Bourdoncle.
+
+    Weak topological ordering is an extension of topological ordering
+    for potentially cyclic graphs.
+
+    A hierarchical ordering of a set is a well-parenthesized
+    permutation of its elements with no consecutive [(]. The elements
+    between two parentheses are called a {e component}, and the first
+    elements of a component is called the {e head}. A weak topological
+    ordering of a graph is a hierarchical ordering of its vertices
+    such that for every edge [u -> v] of the graph, either [u] comes
+    (strictly) before [v], or [v] is the head of a component
+    containing [u].
+
+    One may notice that :
+    - For an acyclic graph, every topological ordering is also a weak
+      topological ordering.
+    - For any graph with the vertices [v1, ..., vN], the following
+      trivial weak topological ordering is valid : [(v1 (v2
+      (... (vN))...))].
+
+    Weak topological ordering are useful for fixpoint computation (see
+    {!ChaoticIteration}). This module aims at computing weak
+    topological orderings which improve the precision and the
+    convergence speed of these analyses.
+
+    @author Thibault Suzanne
+    @see "Efficient chaotic iteration strategies with widenings",
+    François Bourdoncle,
+    Formal Methods in Programming and their Applications,
+    Springer Berlin Heidelberg, 1993
+*)
+
+(** Minimal graph signature for the algorithm *)
+module type G = sig
+  type t
+  module V : Sig.COMPARABLE
+  val iter_vertex : (V.t -> unit) -> t -> unit
+  val iter_succ : (V.t -> unit) -> t -> V.t -> unit
+end
+
+(** The type of the elements of a weak topological ordering over a set
+    of ['a].
+
+    - [Vertex v] represents a single vertex.
+    - [Component (head, cs)] is a component of the wto, that is
+    a sequence of elements between two parentheses. [head] is the head
+    of the component, that is the first element, which is guaranteed to
+    be a vertex by definition. [cs] is the rest of the component.
+*)
+type 'a element =
+  | Vertex of 'a
+  | Component of 'a * 'a t
+
+and 'a t
+(** The type of a sequence of outermost elements in a weak topological
+    ordering. This is also the type of a weak topological ordering
+    over a set of ['a].
+*)
+
+val fold_left : ('a -> 'b element -> 'a) -> 'a -> 'b t -> 'a
+(** Folding over the elements of a weak topological ordering. They are
+    given to the accumulating function according to their order.
+
+    Note that as [element]s present in an ordering of type [t] can
+    contain values of type [t] itself due to the [Component] variant,
+    this function should be used by defining a recursive function [f],
+    which will call [fold_left] with [f] used to define the first
+    parameter.
+*)
+
+module Make : functor (G : G) -> sig
+
+  val recursive_scc : G.t -> G.V.t -> G.V.t t
+  (** [recursive_scc g root_g] computes a weak topological ordering of
+      the vertices of [g], with the general algorithm recursively
+      computing the strongly connected components of [g]. [root_g] is
+      taken as the root of the graph and must be a valid vertex of
+      [g].
+  *)
+
+end

--- a/tests/test_chaotic.ml
+++ b/tests/test_chaotic.ml
@@ -1,0 +1,226 @@
+open Graph
+
+(*
+   Analysis with ChaoticIteration of the following program :
+   X:=0;
+   while X<40 do
+     X:=X+1
+   done
+
+   The analyses uses the interval abstract domain, with widening, and
+   the widening delay given as a parameter in the commande line (0 if
+   no parameter is given).
+
+   Executing this program should print:
+
+   W = WTO, delay=40:
+   1 -> [-∞; +∞]
+   2 -> [0; +∞]
+   3 -> [0; 39]
+   4 -> [40; +∞]
+
+   W = {3}, delay=39:
+   1 -> [-∞; +∞]
+   2 -> [0; +∞]
+   3 -> [0; +∞]
+   4 -> [40; +∞]
+
+   W = WTO, delay=41:
+   1 -> [-∞; +∞]
+   2 -> [0; 40]
+   3 -> [0; 39]
+   4 -> [40; 40]
+
+*)
+
+(* Trivial language, only one variable *)
+
+module Operator = struct
+  type expr =
+    | Var
+    | Int of int
+    | Sum of expr * expr
+
+  type test =
+    | Le
+    | Ge
+
+  type t =
+    | Affect of expr
+    | Test of test * int
+
+  let compare = compare
+
+  let default = Affect Var
+end
+
+open Operator
+
+(* Basic interval domain *)
+
+module Interval = struct
+
+  type num =
+    | MinusInfinity
+    | Int of int
+    | PlusInfinity
+
+  let print_num = function
+    | MinusInfinity -> print_string "-∞"
+    | Int n -> print_int n
+    | PlusInfinity -> print_string "+∞"
+
+  let ( <% ) n1 n2 = match n1, n2 with
+    | MinusInfinity, MinusInfinity
+    | PlusInfinity, PlusInfinity -> failwith "<%"
+    | MinusInfinity, _ -> true
+    | _, PlusInfinity -> true
+    | Int a, Int b -> a < b
+    | _, _ -> false
+
+  let ( >=% ) n1 n2 =
+    not (n1 <% n2)
+
+  let ( <=% ) n1 n2 =
+    n1 <% n2 || n1 = n2
+
+  let ( >% ) n1 n2 =
+    n1 >=% n2 && n1 <> n2
+
+  let min_ n1 n2 =
+    if n1 <=% n2 then n1 else n2
+
+  let max_ n1 n2 =
+    if n1 >=% n2 then n1 else n2
+
+  type t =
+    | Bottom
+    | Bounded of num * num
+
+  let top =
+    Bounded (MinusInfinity, PlusInfinity)
+
+  let equal = ( = )
+
+  let print = function
+    | Bottom -> print_string "⊥"
+    | Bounded (a, b) ->
+      (* Printf is for the weak *)
+      print_string "[";
+      print_num a;
+      print_string "; ";
+      print_num b;
+      print_string "]"
+
+  let join i1 i2 = match i1, i2 with
+    | Bottom, _ -> i2
+    | _, Bottom -> i1
+    | Bounded (a, b), Bounded (c, d) -> Bounded (min_ a c, max_ b d)
+
+  let singleton n =
+    Bounded (Int n, Int n)
+
+  let ( +% ) x y = match x, y with
+    | MinusInfinity, PlusInfinity
+    | PlusInfinity, MinusInfinity -> failwith "+%"
+    | MinusInfinity, _
+    | _, MinusInfinity -> MinusInfinity
+    | PlusInfinity, _
+    | _, PlusInfinity -> PlusInfinity
+    | Int a, Int b -> Int (a + b)
+
+  let rec abstr_expr interval = function
+    | Var -> interval
+    | Int n -> singleton n
+    | Sum (e1, e2) ->
+      match abstr_expr interval e1, abstr_expr interval e2 with
+      | Bottom, _ -> Bottom
+      | _, Bottom -> Bottom
+      | Bounded (a, b), Bounded (c, d) -> Bounded (a +% c, b +% d)
+
+  let abstr_test interval test c = match interval with
+    | Bottom -> Bottom
+    | Bounded (a, b) ->
+      match test with
+      | Le -> if a >% c then Bottom else Bounded (a, min_ b c)
+      | Ge -> if b <% c then Bottom else Bounded (max_ a c, b)
+
+  let analyze (v, op, w) interval = match op with
+    | Affect e -> abstr_expr interval e
+    | Test (test, n) -> abstr_test interval test (Int n)
+
+  let widening i1 i2 = match i1, i2 with
+    | Bottom, _ -> i2
+    | Bounded _, Bottom -> failwith "widening"
+    | Bounded (a, b), Bounded (c, d) ->
+      Bounded (
+        (if a <=% c then a else MinusInfinity),
+        (if b >=% d then b else PlusInfinity)
+      )
+
+end
+
+module Int = struct
+  type t = int
+  let compare = compare
+  let hash = Hashtbl.hash
+  let equal = ( = )
+end
+
+module Data = struct
+  include Interval
+  type edge = int * Operator.t * int
+end
+
+module G = Persistent.Digraph.ConcreteLabeled (Int) (Operator)
+module Wto = WeakTopological.Make (G)
+module Chaotic = ChaoticIteration.Make (G) (Data)
+
+let edges = [
+  1, 2, Affect (Int 0);
+  2, 3, Test (Le, 39);
+  3, 2, Affect (Sum (Var, Int 1));
+  2, 4, Test (Ge, 40);
+]
+
+let g =
+  List.fold_left
+    (fun acc (v, w, op) -> G.add_edge_e acc (G.E.create v op w))
+    G.empty edges
+
+let strategy = Wto.recursive_scc g 1
+
+let print_vertex_data vertex interval =
+  print_int vertex;
+  print_string " -> ";
+  Interval.print interval;
+  print_newline ()
+
+let init v =
+  if v = 1 then Interval.top else Interval.Bottom
+
+let widening_delay1 = 40
+let widening_set1 = ChaoticIteration.FromWto
+
+let widening_delay2 = 39
+let widening_set2 = ChaoticIteration.Predicate (( = ) 3)
+
+let widening_delay3 = 41
+let widening_set3 = ChaoticIteration.FromWto
+
+let result1 = Chaotic.recurse g strategy init widening_set1 widening_delay1
+let result2 = Chaotic.recurse g strategy init widening_set2 widening_delay2
+let result3 = Chaotic.recurse g strategy init widening_set3 widening_delay3
+
+let () =
+  print_endline "W = WTO, delay=40:";
+  Chaotic.M.iter print_vertex_data result1;
+  print_newline ();
+
+  print_endline "W = {3}, delay=39:";
+  Chaotic.M.iter print_vertex_data result2;
+  print_newline ();
+
+  print_endline "W = WTO, delay=41:";
+  Chaotic.M.iter print_vertex_data result3;
+  print_newline ();

--- a/tests/test_wto.ml
+++ b/tests/test_wto.ml
@@ -1,0 +1,62 @@
+open Graph
+
+(*
+  The non-reducible example from Bourdoncle paper
+  Reference is in WeakTopological source
+*)
+
+(* Execution should print something like (i and i' can be switched) :
+   (1 4 1' 4') 2' 3' 2 3 (6 5' 6' 5) *)
+
+module Vertex = struct
+  type t = string
+  let compare = Pervasives.compare
+  let hash = Hashtbl.hash
+  let equal = ( = )
+end
+
+module G = Persistent.Digraph.Concrete (Vertex)
+module Wto = WeakTopological.Make (G)
+
+let rec print_element = function
+  | WeakTopological.Vertex v -> print_string v
+  | WeakTopological.Component (head, components) ->
+    (* Printf is for the weak *)
+    print_string "(";
+    print_string head;
+    print_string " ";
+    print_components components;
+    print_string ")"
+
+and print_components components =
+  WeakTopological.fold_left
+    (fun () elem -> print_element elem; print_string " ")
+    ()
+    components
+
+let edges = [
+  "1", "4";
+  "1", "2";
+  "2", "3";
+  "3", "6";
+  "4", "1'";
+  "5", "6";
+  "6", "5'";
+  "1'", "2'";
+  "1'", "4'";
+  "2'", "3'";
+  "3'", "6'";
+  "4'", "1";
+  "5'", "6'";
+  "6'", "5";
+]
+
+let g =
+  List.fold_left
+    (fun acc (v, w) -> G.add_edge acc v w)
+    G.empty edges
+
+let result = Wto.recursive_scc g "1"
+
+let () =
+  print_components result


### PR DESCRIPTION
This pull request : 
- Adds an option to ocamldoc to explicitely mark generated pages as utf-8. Previously, no option was given, making ocamldoc mark them as iso-8859-1. A (quick) research makes me believe this change does not impact already present pages, and as I needed a non-ascii character in this patch, I thought utf-8 was probably the go-to choice nowadays. In any case, my opinion is that it is a good idea to explicitly specify the charset to be used, even if it is wanted to stay with the default value not to break backwards compatibility (but as I said, I do not think it is actually broken).
- Adds two modules, `WeakTopological` and `ChaoticIteration`. These are used to compute fixpoint on graphs describing equations between states, with a widening option to speed-up computation (and make it terminate). `ChaoticIteration` depends on `WeakTopological`, but as they are different algorithms, I feel like the general library organisation wants to have them in different modules. Please comment if you think they should be grouped.
- Adds two tests for these modules, in the `tests` directory. These tests are not added anywhere in the Makefiles, but they can be compiled and executed manually if someone wants to run them for some reason (like updating the modules).

Please comment if any of these points should be modified.