### PR TITLE
Fix of configuration script to rewrite directory separators in a uniform way on Windows and Linux

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -59,7 +59,7 @@ esac
 
 # OCAMLLIB=`$OCAMLC -v | tail -n 1 | cut -f 4 -d " "`
 # OCAMLLIB=`$OCAMLC -v | tail -n 1 | sed -e 's|[[^:]]*: \(.*\)|\1|' `
-OCAMLLIB=`$OCAMLC -where | tr -d '\r'`
+OCAMLLIB=`$OCAMLC -where | tr -d '\\r' | tr '\\\\' '/'`
 echo "ocaml library path is $OCAMLLIB"
 
 # then we look for ocamlopt; if not present, we issue a warning
@@ -146,7 +146,7 @@ AC_CHECK_PROG(OCAMLFIND,ocamlfind,ocamlfind)
 if test "$OCAMLFIND" = "" ; then
    echo "No ocamlfind detected"
 else
-   OCAMLLIB_BY_FINDLIB=`ocamlfind printconf stdlib | tr -d '\\r'`
+   OCAMLLIB_BY_FINDLIB=`ocamlfind printconf stdlib | tr -d '\\r' | tr '\\\\' '/'`
    if test "$OCAMLLIB_BY_FINDLIB" = "$OCAMLLIB" ; then
       echo "OCamlfind detected and enabled"
    else


### PR DESCRIPTION
This little fix rewrites the directory separators that are used on Windows (backslashes) into Linux-like slashes. Thereby, it fixes issue #39. 