### PR TITLE
Honor SOURCE_DATE_EPOCH

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -114,10 +114,16 @@ graph.cmx: $(CMI) $(CMX)
 
 VERSION=1.8.7
 
+ifdef SOURCE_DATE_EPOCH
+BUILD_DATE=$(shell date -u -d "@$(SOURCE_DATE_EPOCH)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" 2>/dev/null || date)
+else
+BUILD_DATE=$(shell date)
+endif
+
 src/version.ml: Makefile
 	rm -f $@
 	echo "let version = \""$(VERSION)"\"" > $@
-	echo "let date = \""`date`"\"" >> $@
+	echo "let date = \""$(BUILD_DATE)"\"" >> $@
 
 # gtk2 graph editor
 ###################


### PR DESCRIPTION
Hi,

I'm trying to package ocamlgraph for GuixSD, my distribution of choice. Like Debian and many others, we aim to have reproducible software. Ocamlgraph embeds the compilation date and therefore isn't reproducible. SOURCE_DATE_EPOCH is an environment variable that can be used by distributors to set a fixed compilation date and obtain a reproducible build. Its exact purpose is explained here: https://reproducible-builds.org/specs/source-date-epoch/.

With this change, Guix doesn't complain about non-reproducibility anymore, and it doesn't affect any user who don't care about reproducibility.

Thank you :)