### PR TITLE
Enable ocamlgraph to be safe-string compatible

### DIFF
--- a/lib/bitv.ml
+++ b/lib/bitv.ml
@@ -449,11 +449,11 @@ let all_ones v =
 
 let to_string v =
   let n = v.length in
-  let s = String.make n '0' in
+  let s = Buffer.create n in
   for i = 0 to n - 1 do
-    if unsafe_get v i then s.[i] <- '1'
+    Buffer.add_char s (if unsafe_get v i then '1' else '0')
   done;
-  s
+  Buffer.contents s
 
 let print fmt v = Format.pp_print_string fmt (to_string v)
 


### PR DESCRIPTION
Currently, ocamlgraph cannot be compiled on a switch with safe-string enabled. This PR fixes the issue.