### PR TITLE
Minor fixes

### DIFF
--- a/INSTALL.adoc
+++ b/INSTALL.adoc
@@ -7,6 +7,9 @@ Configure with
 
 	./configure
 
+(If the `./configure` file does not exist,
+run `autoconf` first.)
+
 Compile with
 
 	make

--- a/README.adoc
+++ b/README.adoc
@@ -33,7 +33,14 @@ result.
 
 == How to link with OCamlgraph
 
-OCamlgraph is packaged as a single module `Graph`. Link is done as follows:
+You can use the `ocamlgraph` ocamlfind package:
+
+	ocamlfind ocamlopt -package ocamlgraph ...
+
+(To produce an executable, also add the `-linkpkg` option.)
+
+If you want to invoke the compiler directly, OCamlgraph is packaged as
+a single module `Graph`. Linking is done as follows:
 
 bytecode::
 
@@ -42,7 +49,6 @@ bytecode::
 native code::
 
 	ocamlopt graph.cmxa <other files>
-
 
 == Examples
 

--- a/opam
+++ b/opam
@@ -25,7 +25,10 @@ build: [
   [make "install-findlib"]
 ]
 remove: [["ocamlfind" "remove" "ocamlgraph"]]
-depends: ["ocamlfind"]
+depends: [
+  "conf-autoconf"
+  "ocamlfind" {build}
+]
 depopts: [
   "lablgtk"
   "conf-gnomecanvas"


### PR DESCRIPTION
- Update `opam` with a `conf-autoconf` dependency
- Mention the `autoconf` step in INSTALL.adoc
- while we are at it, in the README.adoc, give command-line instructions using `ocamlfind` (I wanted to make a "we are in the 21st century now" joke, but it would be slightly unfair given that ocamlfind only started in 2003.)