### PR TITLE
Fixes #58: Fixpoint computes incorrect node labeling

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@
  * [Coloring] functions now fail if the graph is directed
  * [Coloring] now uses a single, global exception [NoColoring]
  o [Coloring] new function two_color to 2-color a graph (or fail)
+ * [Fixpoint] Take initial labeling of nodes into account (Johannes Kloos)
 
 version 1.8.8, October 17, 2017
 -------------------------------

--- a/Makefile.in
+++ b/Makefile.in
@@ -322,6 +322,9 @@ test: $(CMA) tests/test.ml
 test-bf: $(CMA) tests/test_bf.ml
 	ocaml unix.cma graphics.cma $^
 
+test-fixpoint: $(CMA) tests/test_fixpoint.ml
+	ocaml $^
+
 test-johnson: $(CMA) tests/test_johnson.ml
 	ocaml unix.cma graphics.cma $^
 

--- a/src/fixpoint.ml
+++ b/src/fixpoint.ml
@@ -96,10 +96,7 @@ struct
 
     let rec worklist (data : A.data M.t) (wl : N.t) =
       (* 'meet' an arbitrary number of data-sets *)
-      let meet ~default = function
-        | [] -> default
-        | [x] -> x
-        | x::xs -> List.fold_left (fun a b -> A.join a b) x xs
+      let meet initial xs = List.fold_left A.join initial xs
       in
 
       (* analyze one node, creating a new data-set and node-worklist
@@ -133,7 +130,7 @@ struct
                   (fun (f, src) -> f (M.find src data)) edges
               in
               let node_data = M.find node data in
-              let node_data' = meet ~default:node_data analysis in
+              let node_data' = meet (initial node) analysis in
               if A.equal node_data node_data' then None
               else Some (M.add node node_data' data)
             in
@@ -149,7 +146,7 @@ struct
                   (fun (f, dst) -> f (M.find dst data)) edges
               in
               let node_data = M.find node data in
-              let node_data' = meet ~default:node_data analysis in
+              let node_data' = meet (initial node) analysis in
               if A.equal node_data node_data' then None
               else Some (M.add node node_data' data)
             in

--- a/tests/test_fixpoint.ml
+++ b/tests/test_fixpoint.ml
@@ -1,0 +1,48 @@
+
+(* Test file for Fixpoint *)
+
+let id x = x
+module IntOrdered = struct
+  type t = int
+  let compare: int -> int -> int = compare
+  let hash: int -> int = id
+  let equal: int -> int -> bool = (=)
+end
+module IntSet = Set.Make(IntOrdered)
+module G = Graph.Persistent.Digraph.Concrete(IntOrdered)
+module Divisors = Graph.Classic.P(G)
+module Analysis = struct
+  type data = IntSet.t
+  type edge = G.edge
+  type vertex = G.vertex
+  type g = G.t
+  let direction = Graph.Fixpoint.Backward
+  let join = IntSet.union
+  let equal = IntSet.equal
+  let analyze (_: edge): data -> data = id
+end
+module Fixpoint = Graph.Fixpoint.Make(G)(Analysis)
+
+let pp_int_set pp set =
+  let open Format in
+  let first = ref true in
+  Format.fprintf pp "@[<hov>";
+  IntSet.iter (fun x ->
+      if !first then
+	first := false
+      else 
+	Format.fprintf pp ",@ ";
+      Format.pp_print_int pp x)
+    set;
+  Format.fprintf pp "@]"
+
+let () =
+  let n = 15 in
+  let labels = Fixpoint.analyze IntSet.singleton (Divisors.divisors n) in
+  Format.open_vbox 0;
+  for i = 2 to n do
+    Format.printf "Labels for %d: %a@," i pp_int_set (labels i)
+  done;
+  Format.close_box ();
+  Format.print_flush ()
+


### PR DESCRIPTION
This commit fixes the error described in issue #58 by taking the current node labeling into account when computing the meet of all incoming/outgoing edges.