### PR TITLE
bug fix: polymorphic equality in leaderlist module

### DIFF
--- a/src/leaderlist.ml
+++ b/src/leaderlist.ml
@@ -45,7 +45,7 @@ struct
 
     (* predicate to determine if a node is a leader *)
     let is_leader n =
-      if n = root then true (* the root node is always a leader *)
+      if G.V.equal n root then true (* the root node is always a leader *)
       else
         match G.pred g n with
         | [] ->


### PR DESCRIPTION
Polymorphic equality raises a runtime exception in some situations, for example when instantiating this module with a `Imperative.Digraph.AbstractLabeled` graph:
```
> module G = Graph.Imperative.Digraph.AbstractLabeled(V)(E)
> module L = Graph.Leaderlist.Make(G)
> val g : G.t
> val v : G.V.t
> Leaderlist.leader_lists g v
Uncaught exception:
  
  (Invalid_argument "compare: functional value")

Raised by primitive operation at file "src/leaderlist.ml", line 48, characters 9-17
Called from file "src/leaderlist.ml", line 42, characters 14-17
...
```