### PR TITLE
Remove various usages of polymorphic equality

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,6 +1,7 @@
 
 * marks some incompatible change
 
+ o fix incorrect uses of polymorphic equality (Steffen Smolka, Boris Yakobowski)
  o [Coloring] fixed generation of OCamlDoc documentation
    (contributed by Earnestly)
  * [Coloring] functions now fail if the graph is directed

--- a/src/blocks.ml
+++ b/src/blocks.ml
@@ -99,7 +99,6 @@ end
 module Make_Map(X: COMPARABLE) = struct
   include Map.Make(X)
   type 'a return = 'a t
-  let is_empty m = (m = empty)
   let create ?size:_ () = assert false
   (* never call and not visible for the user thank's to
      signature constraints *)

--- a/src/cliquetree.ml
+++ b/src/cliquetree.ml
@@ -101,8 +101,8 @@ module CliqueTree(Gr : Sig.G) = struct
       (struct
         type t = int
         let compare : t -> t -> int = Pervasives.compare
-        let hash = Hashtbl.hash
-        let equal x y = x = y
+        let hash (x:t) = Hashtbl.hash x
+        let equal (x:int) (y:int) = x = y
       end)
 
   module CliqueTreeE = struct

--- a/src/components.ml
+++ b/src/components.ml
@@ -40,7 +40,7 @@ module Make(G: G) = struct
     let numdfs = ref 0 in
     let numcomp = ref 0 in
     let rec pop x = function
-      | (y, w) :: l when y > x ->
+      | ((y: int), w) :: l when y > x ->
         H.add hashcomp w !numcomp;
         pop x l
       | l -> l

--- a/src/flow.ml
+++ b/src/flow.ml
@@ -684,7 +684,7 @@ struct
       Mark.clear ();
       Mark.set s None Mark.Plus;
       let a' = internal_loop a in
-      if a = a' then a else external_loop a'
+      if F.compare a a' = 0 then a else external_loop a'
     in
     let a = external_loop F.zero in
     (fun e -> try Result.find r e with Not_found -> F.flow (G.E.label e)), a

--- a/src/mcs_m.ml
+++ b/src/mcs_m.ml
@@ -42,9 +42,9 @@ module MaximalCardinalitySearch = struct
         if H.mem h x then
           false
         else
-        if x = v then true
+        if G.V.equal x v then true
         else
-        if NewV.weight x < maxw || x = u then
+        if NewV.weight x < maxw || G.V.equal x u then
           begin
             H.add h x ();
             G.fold_succ
@@ -80,7 +80,7 @@ module MaximalCardinalitySearch = struct
                let s =
                  G.fold_vertex
                    (fun x s ->
-                      if x = v then s
+                      if G.V.equal x v then s
                       else
                       if check_path g' x v then
                         VerticesSet.add x s
@@ -128,9 +128,9 @@ module MaximalCardinalitySearch = struct
         if H.mem h x then
           false
         else
-        if x = v then true
+        if G.V.equal x v then true
         else
-        if NewV.weight x < maxw || x = u then begin
+        if NewV.weight x < maxw || G.V.equal x u then begin
           H.add h x ();
           G.fold_succ
             (fun x found ->
@@ -156,7 +156,7 @@ module MaximalCardinalitySearch = struct
         let s =
           G.fold_vertex
             (fun x s ->
-               if x = v then s
+               if G.V.equal x v then s
                else
                if check_path g' x v then
                  VerticesSet.add x s

--- a/src/nonnegative.ml
+++ b/src/nonnegative.ml
@@ -45,7 +45,7 @@ module Imperative
         let v = G.E.dst e in
         print_string ("-(" ^ (sov v) ^ ")");
         v) v0 cycle in
-    assert (v0 = v1);
+    assert (G.V.equal v0 v1);
     print_string "\n"
   let dump_set = S.iter (fun x -> print_string ((sov x) ^ ", "))
   let dump (src, dist) =

--- a/src/strat.ml
+++ b/src/strat.ml
@@ -103,14 +103,14 @@ end = struct
   let rec eq l1 l2 = match l1, l2 with
       [], [] -> true
     | e1 :: l1', e2 :: l2' ->
-      (e1 = e2) && (eq l1' l2')
+      (G.V.compare e1 e2 = 0) && (eq l1' l2')
     | _ -> false
 
   let rec eq_mem i l1 l2 = match l1, l2 with
       [], [] -> (true, false)
     | e1 :: l1', e2 :: l2' ->
-      if e1 = e2 then
-        if e1 = i then (eq l1' l2', true)
+      if G.V.compare e1 e2 = 0 then
+        if G.V.compare e1 i = 0 then (eq l1' l2', true)
         else eq_mem i l1' l2'
       else (false, false)
     | _ -> (false, false)

--- a/src/topological.ml
+++ b/src/topological.ml
@@ -74,7 +74,7 @@ struct
   module H = Hashtbl.Make(G.V)
   module C = Path.Check(G)
 
-  let choose ~old (v, n) =
+  let choose ~old (v, n: G.V.t * int) =
     let l, min = old in
     if n = min then v :: l, n
     else if n < min then [ v ], n


### PR DESCRIPTION
In most cases, this fixes latent bugs, when e.g. keys cannot
safely be compared using Pervasives.compare