### PR TITLE
do not embed version and timestamp information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 /src/dot_parser.mli
 /src/dot_parser.output
 /src/gml.ml
-/src/version.ml
 /www/index.en.html
 /www/index.fr.html
 /www/version.prehtml

--- a/Makefile.in
+++ b/Makefile.in
@@ -67,7 +67,7 @@ endif
 OCAMLGRAPH_LIB= unionfind heap bitv persistentQueue
 OCAMLGRAPH_LIB:=$(patsubst %, $(OCAMLGRAPH_LIBDIR)/%.cmo, $(OCAMLGRAPH_LIB))
 
-CMO =	version util blocks persistent imperative \
+CMO =	util blocks persistent imperative \
 	delaunay builder classic rand oper \
 	components path nonnegative traverse coloring topological kruskal flow \
 	prim dominator graphviz gml dot_parser dot_lexer dot pack \
@@ -86,8 +86,7 @@ CMI = sig sig_pack dot_ast
 CMI := $(patsubst %, src/%.cmi, $(CMI))
 
 GENERATED = META \
-	src/gml.ml src/version.ml \
-	src/dot_parser.ml src/dot_parser.mli src/dot_lexer.ml
+	src/gml.ml src/dot_parser.ml src/dot_parser.mli src/dot_lexer.ml
 
 $(CMX): OFLAGS += -for-pack Graph
 
@@ -113,17 +112,6 @@ graph.cmx: $(CMI) $(CMX)
 	$(OCAMLOPT) $(INCLUDES) -pack -o $@ $^
 
 VERSION=1.8.8
-
-ifdef SOURCE_DATE_EPOCH
-BUILD_DATE=$(shell date -u -d "@$(SOURCE_DATE_EPOCH)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" 2>/dev/null || date)
-else
-BUILD_DATE=$(shell date)
-endif
-
-src/version.ml: Makefile
-	rm -f $@
-	echo "let version = \""$(VERSION)"\"" > $@
-	echo 'let date = "'"$(BUILD_DATE)"'"' >> $@
 
 # gtk2 graph editor
 ###################
@@ -472,7 +460,7 @@ META: META.in Makefile
 
 DOCFILES=$(NAME).ps $(NAME).html
 
-NODOC	= blocks dot_parser dot_lexer version
+NODOC	= blocks dot_parser dot_lexer
 NODOC	:= $(patsubst %, $(OCAMLGRAPH_SRCDIR)/%.cmo, $(NODOC))
 DOC_CMO	= $(filter-out $(NODOC) $(OCAMLGRAPH_LIB), $(CMO))
 DOC_SRC	= $(CMI:.cmi=.mli) $(DOC_CMO:.cmo=.mli) $(DOC_CMO:.cmo=.ml)


### PR DESCRIPTION
#54 introduced the timestamp `date` to honor the SOURCE_DATE_EPOCH. This is insufficient if the reproducibility goal is to reproduce under any LOCALE (since the output of `date` depends on the locale set in your environment).

From #54 `Actually, I don't even remember why I chose to have the compilation date as part of the information contained in ocamlgraph. I could simply remove it.`, this is why I open this PR which removes the timestamp and version information from ocamlgraph.

If you think there's value in version or date informaion, I'm fine adjusting this PR to remove less. I (non-exhaustively) searched for users of `Graph.Version.` and couldn't find any. I usually install ocamlgraph via opam, and in this case the version information is carried by other means (META) already.