### PR TITLE
Add missing rankdir directions

### DIFF
--- a/src/graphviz.ml
+++ b/src/graphviz.ml
@@ -84,7 +84,9 @@ let fprint_arrow_style ppf = function
 
 let fprint_dir ppf = function
     `TopToBottom -> fprintf ppf "TB"
+  | `BottomToTop -> fprintf ppf "BT"
   | `LeftToRight -> fprintf ppf "LR"
+  | `RightToLeft -> fprintf ppf "RL"
 
 type symbseq =
   | COMMA
@@ -633,7 +635,7 @@ module DotAttributes = struct
     | `Quantum of float
     (** If not [0.0], node label dimensions will be rounded to integral
         multiples of it.  Default value is [0.0]. *)
-    | `Rankdir of [ `TopToBottom | `LeftToRight ]
+    | `Rankdir of [ `TopToBottom | `BottomToTop | `LeftToRight | `RightToLeft ]
     (** Direction of rank ordering.  Default value is [`TopToBottom]. *)
     | `Ratio of [ `Float of float | `Fill | `Compress| `Auto ]
     (** Sets the aspect ratio. *)

--- a/src/graphviz.mli
+++ b/src/graphviz.mli
@@ -272,7 +272,7 @@ module DotAttributes : sig
     | `Quantum of float
     (** If not [0.0], node label dimensions will be rounded to integral
         multiples of it.  Default value is [0.0]. *)
-    | `Rankdir of [ `TopToBottom | `LeftToRight ]
+    | `Rankdir of [ `TopToBottom | `BottomToTop | `LeftToRight | `RightToLeft ]
     (** Direction of rank ordering.  Default value is [`TopToBottom]. *)
     | `Ratio of [ `Float of float | `Fill | `Compress| `Auto ]
     (** Sets the aspect ratio. *)


### PR DESCRIPTION
This adds the missing `rankdir` directions. Fixes #92.