### PR TITLE
Fix regexp for detecting OCaml version

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -44,7 +44,7 @@ if test "$OCAMLC" = no ; then
 fi
 
 # we extract Ocaml version number and library path
-OCAMLVERSION=`$OCAMLC -v | sed -n -e 's|.*version *\(.*\)$|\1|p' `
+OCAMLVERSION=`$OCAMLC -v | sed -n -e 's|The O.*, version *\(.*\)$|\1|p' `
 echo "ocaml version is $OCAMLVERSION"
 
 case $OCAMLVERSION in


### PR DESCRIPTION
The current regexp has 'false positives' when the OCaml compiler is
installed in a patch containing 'version '. Fix this by using a
more constrained regexp.

Fixes #96

See https://github.com/ocaml/ocaml/blob/4823934182b04/driver/compenv.ml#L26 for the implementation of the version information in the OCaml compiler
