### PR TITLE
[dot] ensure .dot output ends with a newline

### DIFF
--- a/src/graphviz.ml
+++ b/src/graphviz.ml
@@ -576,7 +576,7 @@ struct
     fprintf ppf "%t@ " print_nodes;
     fprintf ppf "%t@ " print_subgraphs;
     fprintf ppf "%t@ " print_edges;
-    fprintf ppf "@]}@]"
+    fprintf ppf "@]}@;@]"
 
   (** [output_graph oc graph] pretty prints the graph [graph] in the dot
       language on the channel [oc]. *)


### PR DESCRIPTION
tiny PR to ensure that a `.dot` file produced by OCamlGraph will end with a newline. Having a text file without it can occasionally confuse some scripts.