### PR TITLE
Fix typo in documentation of Components regarding order

### DIFF
--- a/src/components.mli
+++ b/src/components.mli
@@ -38,7 +38,7 @@ module Make (G: G) : sig
       number. In particular, [f u = f v] if and only if [u] and
       [v] are in the same component. Another property of the
       numbering is that components are numbered in a topological
-      order: if there is an arc from [u] to [v], then [f u >= f u]
+      order: if there is an arc from [u] to [v], then [f u >= f v]
 
       Not tail-recursive.
       Complexity: O(V+E)


### PR DESCRIPTION
I mean... the documentation was not technically wrong! just not very helpful.

To check the order (because I wouldn't trust my opinion just from reading the code), I did:
```ocaml
utop # module G = Graph.Persistent.Digraph.Concrete(struct include Int let hash = Hashtbl.hash end);;
utop # module Components = Graph.Components.Make(G);;
utop # G.add_edge G.empty 0 1 |> Components.scc_array;;
- : int list array = [|[1]; [0]|]
```
So, u = 0 and v = 1. We have u -> v and f(u) =1 >= 0 = f(v). Right?