### PR TITLE
FASH algorithm for minimal feedback arc sets

### DIFF
--- a/src/cycles.ml
+++ b/src/cycles.ml
@@ -1,0 +1,319 @@
+
+type weight =
+  | Normal of int
+  | Obligatory of int
+
+module Fashwo
+ (GB : sig
+         include Builder.S
+         val weight : G.edge -> weight
+       end)
+=
+struct
+  module G = GB.G
+
+  exception Stuck of G.vertex list
+
+  module IM = Map.Make (Int)
+  module VM = Map.Make (G.V)
+  module VS = Set.Make (G.V)
+
+  (* The algorithm of Eades, Lin, and Smyth (ELS 1993) works by "scheduling"
+     vertexes onto two lists called s1 and s2. At each iteration a vertex is
+     chosen, scheduled, and removed from the graph. Arcs from a newly scheduled
+     node toward nodes already in s1 are classified as "leftward"; they are
+     included in the generated feedback arc set. "Rightward" arcs, to vertexes
+     in s2 or that have not yet been scheduled, are not included in the
+     feedback arc set. The algorithm tries to maximize the number of rightward
+     arcs and thereby minimize the number of leftward ones. Source vertexes,
+     those with no incoming arcs in the current graph (i.e., because all its
+     predecssors have already been scheduled), are appended directly onto s1
+     and do not induce any feedback arcs. Sink vertexes are consed directly
+     onto s2 and do not induce any feedback arcs. Otherwise, the algorithm
+     chooses a vertex to maximize the difference between the number of
+     outgoing arcs and the number of incoming ones: the (remaining) incoming
+     arcs must be included in the feedback arc set. The difference between the
+     number of rightward arcs (no cost) and the number of leftward arcs
+     (feedback arcs) is called "delta". The algorithm is implemented
+     efficiently by using a data structure to group unscheduled vertexes
+     according to their delta value. When more than one vertex has the maximum
+     delta value, the original algorithm makes an arbitrary choice. The
+     algorithm of Eades and Lin (EL 1995) makes the choice using a heuristic
+     that maximizes the difference between incoming arcs and outgoing ones in
+     the vertexes that remain at the end of the iteration as such vertexes are
+     the most "unbalanced" and thus less likely to contribute to the feedback
+     arc set in future iterations. The EL 1995 algorithm includes a further
+     refinement to ignore chains of vertexes when looking for unbalanced ones,
+     since such chains do not contribute feedback arcs.
+
+     Since we just want to produce a list of feedback arcs, we don't bother
+     tracking order in s1, and we only track s2 to properly handle the
+     preprocessing optimization that removes two cycles. We maintain lists of
+     source and sink vertexes (scheduled but not yet removed from the graph)
+     and a map from delta values to sets of vertexes. As the delta value map
+     caches the state of the graph, it must be updated when the a vertex is
+     scheduled and removed from the graph. Additionally, we remember which two
+     cycles were removed during preprocessing and ensure that one of their
+     arcs is included in the feedback arc set, depending on whichever of the
+     two interlinked vertexes is scheduled first. *)
+
+  type t = {
+    s1         : VS.t;             (* vertexes placed "at left" *)
+    s2         : VS.t;             (* vertexes placed "at right";
+                                      only needed to optimize for two_cycles *)
+    sources    : VS.t;             (* vertexes with no incoming arcs *)
+    sinks      : VS.t;             (* vertexes with no outgoing arcs *)
+    delta_bins : VS.t IM.t;        (* group vertexes by delta value *)
+    vertex_bin : int VM.t;         (* map each vertex to its bin *)
+    two_cycles : G.edge list VM.t; (* edges for 2-cycles *)
+    fas        : G.edge list;      (* current feedback arc set *)
+  }
+
+  let empty = {
+      s1 = VS.empty;
+      s2 = VS.empty;
+      sources = VS.empty;
+      sinks = VS.empty;
+      delta_bins = IM.empty;
+      vertex_bin = VM.empty;
+      two_cycles = VM.empty;
+      fas = [];
+    }
+
+  let add_to_bin delta v ({ delta_bins; vertex_bin; _ } as st) =
+    { st with delta_bins =
+                IM.update delta (function None -> Some (VS.singleton v)
+                                        | Some vs -> Some (VS.add v vs))
+                  delta_bins;
+                vertex_bin = VM.add v delta vertex_bin }
+
+  let remove_from_bin v ({ delta_bins; vertex_bin; _ } as st) =
+    match VM.find_opt v vertex_bin with
+    | None -> st
+    | Some delta ->
+        { st with delta_bins =
+                    IM.update delta (function None -> None
+                                            | Some vs -> Some (VS.remove v vs))
+                      delta_bins;
+                  vertex_bin = VM.remove v vertex_bin }
+
+  (* Calculate the sums of incoming and outgoing edge weights, ignoring
+     obligatory arcs; they must be respected so their weight is irrelevant. *)
+  let weights g v =
+    let add_pweight e (s, b) =
+      match GB.weight e with Obligatory _ -> (s, true) | Normal w -> (s + w, b)
+    in
+    let add_sweight e s =
+      match GB.weight e with Obligatory w -> s + w | Normal w -> s + w
+    in
+    let inw, blocked = G.fold_pred_e add_pweight g v (0, false) in
+    let outw = G.fold_succ_e add_sweight g v 0 in
+    blocked, inw, outw
+
+  let add_vertex g v delta ({ sources; sinks; _ } as st) =
+    let ind, outd = G.in_degree g v, G.out_degree g v in
+    if ind = 0 then { st with sources = VS.add v sources }
+    else if outd = 0 then { st with sinks = VS.add v sinks }
+    else add_to_bin delta v st
+
+  (* Initialize the state for a given vertex. *)
+  let init_vertex g v st =
+    let blocked, inw, outw = weights g v in
+    if blocked then st else add_vertex g v (outw - inw) st
+
+  let init g = G.fold_vertex (init_vertex g) g empty
+
+  (* Move v from the bin for delta to sources, sinks, or another bin. *)
+  let shift_bins g v delta' st0 = add_vertex g v delta' (remove_from_bin v st0)
+
+  (* Before removing v from the graph, update the state of its sucessors. *)
+  let update_removed_succ g' e st =
+    let v = G.E.dst e in
+    let still_blocked, inw', outw' = weights g' v in
+    if still_blocked then st else shift_bins g' v (outw' - inw') st
+
+  (* Before removing v from the graph, update the state of its predecessors. *)
+  let update_removed_pred g' e ({ sinks; _ } as st) =
+    let v = G.E.src e in
+    let blocked, inw', outw' = weights g' v in
+    match GB.weight e with
+    | Obligatory _ ->
+        if blocked || outw' > 0 then st
+        else (* not blocked && outw' = 0 *)
+        { (remove_from_bin v st) with sinks = VS.add v sinks }
+    | Normal _ ->
+        if blocked then st else shift_bins g' v (outw' - inw') st
+
+  (* Remove a vertex from the graph and update the data structures for its
+     succesors and predecessors. *)
+  let remove_vertex g v st =
+    let g' = GB.remove_vertex g v in
+    (g', G.fold_succ_e (update_removed_succ g') g v st
+         |> G.fold_pred_e (update_removed_pred g') g v)
+
+  (* The original article proposes preprocessing the graph to condense long
+     chains of vertexes. This works together with the heuristic for generating
+     unbalanced vertexes, since the intermediate nodes on the chain do not
+     contribute any leftward arcs (when the last vertex is removed, they
+     become a sequence of sinks). Using such a preprocessing step with
+     weighted edges risks removing good feedback arcs, i.e., those with a big
+     difference between outgoing and incoming weights. That is why here we
+     use on-the-fly condensation, even if there is a risk of recomputing the
+     same result several times. *)
+  let rec condense w g v =
+    if G.out_degree g v = 1 then
+      match G.pred g v with
+      | [u] when not (G.V.equal u w) -> condense w g u
+      | _ -> v
+    else v
+
+  (* Find the vertex v that has the most "unbalanced" predecessor u. Most
+     unbalanced means the biggest difference between the input weights and
+     output weights. Skip any vertex with an incoming obligatory arc. *)
+  let takemax g v imax =
+    let check_edge e max = (* check u -> v *)
+      let u_blocked, u_inw, u_outw =
+        weights g (condense (G.E.dst e) g (G.E.src e)) in
+      let u_w = u_inw - u_outw in
+      match max with
+      | Some (None, _)
+      | None -> Some ((if u_blocked then None else Some u_w), v)
+      | Some (Some x_w, _) when u_w > x_w -> Some (Some u_w, v)
+      | _ -> max
+    in
+    G.fold_pred_e check_edge g v imax
+
+  (* Look for the vertex with the highest delta value that is not the target
+     of an obligatory arc. Use the "unbalanced" heuristic impllemented in
+     [takemax] to discriminate between competing possibilities. If a vertex
+     is found, remove it from the returned delta bins. *)
+  let max_from_deltas g ({ delta_bins; _ } as st) =
+    let rec f = function
+      | Seq.Nil -> None
+      | Seq.Cons ((_, dbin), tl) ->
+          (match VS.fold (takemax g) dbin None with
+           | None -> f (tl ())
+           | Some (_, v) -> Some (v, remove_from_bin v st))
+    in
+    f (IM.to_rev_seq delta_bins ())
+
+  (* Include any leftward arcs due to the two-cycles that were removed by
+     preprocessing. *)
+  let add_from_two_cycles s1 s2 two_cycles v fas =
+    let bf es b = if G.V.equal (G.E.dst b) v then b::es else es in
+    let f es e =
+      let w = G.E.dst e in
+      if VS.mem w s1 then e::es
+      else if VS.mem w s2 then
+        (* the two-cycle partner has already been scheduled as sink, so
+           the feedback edges come from it. *)
+        match VM.find_opt w two_cycles with
+        | None -> es
+        | Some bs -> List.fold_left bf es bs
+      else es in
+    match VM.find_opt v two_cycles with
+    | None -> fas
+    | Some es -> List.fold_left f fas es
+
+  (* Shift a given vertex onto s1, and add any leftward arcs to the feedback
+     arc set. *)
+  let schedule_vertex g (v, ({ s1; s2; fas; two_cycles; _ } as st)) =
+    let add_to_fas e es = if VS.mem (G.E.src e) s1 then es else e::es in
+    (v, { st with s1 = VS.add v s1;
+                  fas = G.fold_pred_e add_to_fas g v fas
+                          |> add_from_two_cycles s1 s2 two_cycles v })
+
+  (* Take the next available vertex from, in order, sources, sinks, or the
+     highset possible delta bin. *)
+  let choose_vertex g ({ s1; s2; sources; sinks; two_cycles; fas; _ } as st0) =
+    match VS.choose_opt sources with
+    | Some v ->
+        Some (v, { st0 with sources = VS.remove v sources;
+                            sinks = VS.remove v sinks;
+                            s1 = VS.add v s1;
+                            fas = add_from_two_cycles s1 s2 two_cycles v fas })
+    | None ->
+        (match VS.choose_opt sinks with
+         | Some v ->
+             Some (v, { st0 with sinks = VS.remove v sinks;
+                                 s2 = VS.add v s2;
+                                 fas = add_from_two_cycles s1 s2 two_cycles v fas })
+         | None -> Option.map (schedule_vertex g) (max_from_deltas g st0))
+
+  let add_two_cycle_edge two_cycles e =
+    VM.update (G.E.src e) (function None -> Some [e]
+                                  | Some es -> Some (e :: es)) two_cycles
+
+  let same_weight w e =
+    match GB.weight e with
+    | Obligatory _ -> false
+    | Normal w' -> w' = w
+
+  (* For every pair of distinct vertexes A and B linked to each other by
+     edges A -ab-> B and B -ba-> A with the same weight, update the mapping
+     by linking A to ab, and B to ba, and remove the edges from the graph.
+     When A is scheduled, if B is already in s1 then the edge ab is a
+     feedback arc, and similarly for B and ba. The principle is that there
+     will be a feedback arc regardless of whether A is "scheduled" before B or
+     vice versa, therefore such cycles should not constrain vertex choices. *)
+  let remove_two_cycles g0 =
+    let f e ((g, cycles) as unchanged) =
+      match GB.weight e with
+      | Obligatory _ -> unchanged
+      | Normal w ->
+          if List.length (G.find_all_edges g0 (G.E.src e) (G.E.dst e)) > 1
+          (* invalid for graphs like: { A -1-> B, A -2-> B, B -3-> A *)
+          then raise Exit
+          else
+            let back_edges =
+              G.find_all_edges g0 (G.E.dst e) (G.E.src e)
+              |> List.filter (same_weight w)
+            in
+            if back_edges = [] then unchanged
+            else (GB.remove_edge_e g e,
+                  List.fold_left add_two_cycle_edge cycles back_edges)
+    in
+    try
+      G.fold_edges_e f g0 (g0, VM.empty)
+    with Exit -> (g0, VM.empty)
+
+  (* All self loops must be broken, so just add them straight into the
+     feedback arc set. *)
+  let remove_self_loops g0 =
+    let f v (g, fas) =
+      let self_loops = G.find_all_edges g0 v v in
+      (List.fold_left GB.remove_edge_e g self_loops,
+       List.rev_append self_loops fas)
+    in
+    G.fold_vertex f g0 (g0, [])
+
+  (* Remove any arcs between strongly connected components. There can be no
+     cycles between distinct sccs by definition. *)
+  module C = Components.Make(G)
+  module Emap = Gmap.Edge(G)(struct include GB.G include GB end)
+
+  let disconnect_sccs g =
+    let nsccs, fscc = C.scc g in
+    let in_same_scc e =
+      if fscc (G.E.src e) = fscc (G.E.dst e) then Some e else None
+    in
+    if nsccs < 2 then g
+    else Emap.filter_map in_same_scc g
+
+  let feedback_arc_set g0 =
+    let rec loop (g, st) =
+      match choose_vertex g st with
+      | Some (v, st') when G.mem_vertex g v -> loop (remove_vertex g v st')
+      | Some (_, st') -> loop (g, st')
+      | None ->
+          let remaining = IM.fold (Fun.const VS.union) st.delta_bins VS.empty in
+          if VS.is_empty remaining then st.fas
+          else raise (Stuck (VS.elements remaining))
+    in
+    let g1 = disconnect_sccs g0 in
+    let g2, fas = remove_self_loops g1 in
+    let g3, two_cycles = remove_two_cycles g2 in
+    loop (g3, { (init g3) with fas; two_cycles })
+
+end
+

--- a/src/cycles.mli
+++ b/src/cycles.mli
@@ -1,0 +1,71 @@
+(**************************************************************************)
+(*                                                                        *)
+(*  Ocamlgraph: a generic graph library for OCaml                         *)
+(*  Copyright (C) 2004-2022                                               *)
+(*  Sylvain Conchon, Jean-Christophe Filliatre and Julien Signoles        *)
+(*                                                                        *)
+(*  This software is free software; you can redistribute it and/or        *)
+(*  modify it under the terms of the GNU Library General Public           *)
+(*  License version 2.1, with the special exception on linking            *)
+(*  described in file LICENSE.                                            *)
+(*                                                                        *)
+(*  This software is distributed in the hope that it will be useful,      *)
+(*  but WITHOUT ANY WARRANTY; without even the implied warranty of        *)
+(*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                  *)
+(*                                                                        *)
+(**************************************************************************)
+
+(** Algorithms related to cycles in directed graphs. *)
+
+type weight =
+  | Normal of int
+    (** Weighted arc that can be included in the feedback set. The
+        weight must be zero (not normally a good choice) or positive
+        (1 may be a good choice). *)
+  | Obligatory of int
+    (** Obligatory arc that cannot be returned in the feedback set.
+        Set the weight to zero to completely ignore obligatory arcs
+        when choosing which vertex to schedule. Set it to a positive
+        value (1 may be a good choice) to adjust the preference for
+        choosing vertexes that may "unblock" other vertexes by
+        removing their incoming obligatory arcs. *)
+
+(** Adaptation of the FASH algorithm of Eades and Lin (1995) to handle
+    edge weights and obligatory arcs. The algorithm tries to minimize the
+    total weight of the returned feedback arc set. Obligatory arcs are
+    respected and never returned in the feedback arc set, an exception is
+    raised if the obligatory arcs form a cycle. The adapted algorithm is
+    hereby called FASHWO: “feedback arc set heuristic + weights and
+    obligations”.
+
+    For a graph G and any one of its feedback arc sets F, the graph G - F is
+    obviously acyclic. If F is minimal, i.e., adding any of its edges to G - F
+    would introduce a cycle, then reversing, rather than removing, the
+    feedback arcs also gives an ayclic graph, [G - F + F^R]. In fact, Eades
+    and Lin define the feedback arc set as "a set of arcs whose reversal makes
+    G acyclic".
+
+    @see <https://mathoverflow.net/a/234023/> David Epstein proof about reversed arcs *)
+module Fashwo
+ (GB : sig
+         include Builder.S
+
+         (** Assign weights to edges. *)
+         val weight : G.edge -> weight
+       end) :
+sig
+  (** Raised if cycles remain and all the remaining vertexes are obligatory.
+      The argument gives the list of remaining vertexes. *)
+  exception Stuck of GB.G.vertex list
+
+  (** Return a minimal set of arcs whose removal or reversal would make the
+      given graph acyclic.
+
+      By minimal, we mean that each arc in the returned list must be removed
+      or reversed, i.e., none are superfluous. Since a heuristic is used, the
+      returned list may not be a minimum feedback arc set. Finding the {i
+      minimum feedback arc set}, dually, the {i maximum acyclic subgraph} is
+      NP-hard for general graphs. *)
+  val feedback_arc_set : GB.G.t -> GB.G.edge list
+end
+

--- a/src/graph.ml
+++ b/src/graph.ml
@@ -12,6 +12,7 @@ module Rand = Rand
 module Oper = Oper
 module Components = Components
 module Path = Path
+module Cycles = Cycles
 module Nonnegative = Nonnegative
 module Traverse = Traverse
 module Coloring = Coloring

--- a/tests/dune
+++ b/tests/dune
@@ -156,6 +156,25 @@
  (modules test_saps)
  (libraries graph))
 
+;; Rules for the test_cycles test
+
+(rule
+ (with-stdout-to
+  test_cycles.output
+  (run ./test_cycles.exe)))
+
+(rule
+ (alias runtest)
+ (action
+  (progn
+   (diff test_cycles.expected test_cycles.output)
+   (echo "test_cycles: all tests succeeded.\n"))))
+
+(executable
+ (name test_cycles)
+ (modules test_cycles)
+ (libraries graph))
+
 ;; Rules for the weak topological test
 
 (rule

--- a/tests/test_cycles.expected
+++ b/tests/test_cycles.expected
@@ -1,0 +1,3 @@
+cycles1 = { 3 -> 2 } (cycles to no cycles)
+cycles2 = { 7 -> 5, 3 -> 1 } (cycles to no cycles)
+cycles3 = { 4 -> 2, 3 -> 1 } (cycles to no cycles)

--- a/tests/test_cycles.ml
+++ b/tests/test_cycles.ml
@@ -1,0 +1,100 @@
+
+(* Test file for Cycles module *)
+
+open Graph
+
+module Int = struct
+  type t = int
+  let compare = compare
+  let hash = Hashtbl.hash
+  let equal = (=)
+  let default = 0
+end
+
+let pp_comma p () = Format.(pp_print_char p ','; pp_print_space p ())
+let pp_edge p (s, d) = Format.fprintf p "%d -> %d" s d
+
+module GP = Persistent.Digraph.Concrete(Int)
+
+module GPDFS = Traverse.Dfs (GP)
+
+let pp_has_cycles p g =
+  if GPDFS.has_cycle g
+  then Format.pp_print_string p "cycles"
+  else Format.pp_print_string p "no cycles"
+
+module FW = Cycles.Fashwo(struct
+    include Builder.P(GP)
+    let weight _ = Cycles.Normal 1
+  end)
+
+(* Eades and Linh, "A Heuristic for the Feedback Arc Set Problem", Fig. 1 *)
+let g1 =
+  List.fold_left (fun g (s, d) -> GP.add_edge g s d) GP.empty
+    [ (1, 4);
+      (1, 3);
+      (2, 1);
+      (2, 4);
+      (3, 2);
+      (4, 3);
+    ]
+let cycles1 = FW.feedback_arc_set g1
+let g1' = List.fold_left (fun g (s, d) -> GP.remove_edge g s d) g1 cycles1
+
+let () =
+  Format.(printf "cycles1 = @[<hv 2>{ %a }@] (%a to %a)@."
+    (pp_print_list ~pp_sep:pp_comma pp_edge) cycles1
+    pp_has_cycles g1
+    pp_has_cycles g1')
+
+(* Eades and Linh, "A Heuristic for the Feedback Arc Set Problem", Fig. 5 *)
+let g2 =
+  List.fold_left (fun g (s, d) -> GP.add_edge g s d) GP.empty
+    [ (1, 2);
+      (1, 4);
+      (2, 3);
+      (2, 4);
+      (3, 1);
+      (4, 8);
+      (5, 3);
+      (5, 6);
+      (6, 7);
+      (7, 5);
+      (8, 6);
+      (8, 7);
+    ]
+let cycles2 = FW.feedback_arc_set g2
+let g2' = List.fold_left
+            (fun g (s, d) -> GP.add_edge (GP.remove_edge g s d) d s)
+            g2 cycles2
+
+let () =
+  Format.(printf "cycles2 = @[<hv 2>{ %a }@] (%a to %a)@."
+    (pp_print_list ~pp_sep:pp_comma pp_edge) cycles2
+    pp_has_cycles g2
+    pp_has_cycles g2')
+
+(* Eades and Linh, "A Heuristic for the Feedback Arc Set Problem", Fig. 6 *)
+let g3 =
+  List.fold_left (fun g (s, d) -> GP.add_edge g s d) GP.empty
+    [ (1, 2);
+      (1, 5);
+      (2, 6);
+      (3, 1);
+      (4, 2);
+      (4, 3);
+      (5, 3);
+      (5, 6);
+      (6, 4);
+    ]
+let cycles3 = FW.feedback_arc_set g3
+let g3' = List.fold_left
+            (fun g (s, d) -> GP.add_edge (GP.remove_edge g s d) d s)
+            g3 cycles3
+
+let () =
+  Format.(printf "cycles3 = @[<hv 2>{ %a }@] (%a to %a)@."
+    (pp_print_list ~pp_sep:pp_comma pp_edge) cycles3
+    pp_has_cycles g3
+    pp_has_cycles g3')
+


### PR DESCRIPTION
Implementation of a published heuristic (FASH of Eades, Linh, and Smyth) for calculating a minimal (not necessarily minimum) feedback arc set. Extended with support for obligatory arcs (not to be included in the feedback arc set) and weights (lighter is better).