### PR TITLE
Remove the .merlin file

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -1,9 +1,0 @@
-S src
-S lib
-S dgraph
-B src
-B lib
-B dgraph
-B .
-PKG lablgtk2
-FLG -w +a -w -4 -w -44 -w -48 -w -29


### PR DESCRIPTION
Merlin seems to "collaborate" with dune automatically. In any case, it works better without the `.merlin` file.