### PR TITLE
Convert from int32 for large integer literals in bitv.ml

### DIFF
--- a/src/lib/bitv.ml
+++ b/src/lib/bitv.ml
@@ -545,7 +545,7 @@ let of_int32_us i = match Sys.word_size with
             bits = [| (Int32.to_int i) land max_int;
                       let hi = Int32.shift_right_logical i 30 in
                       (Int32.to_int hi) land 1 |] }
-  | 64 -> { length = 31; bits = [| (Int32.to_int i) land 0x7fffffff |] }
+  | 64 -> { length = 31; bits = [| (Int32.to_int i) land (Int32.to_int 0x7fffffffl) |] }
   | _ -> assert false
 let to_int32_us v =
   if v.length < 31 then invalid_arg "Bitv.to_int32_us";
@@ -554,7 +554,7 @@ let to_int32_us v =
         Int32.logor (Int32.of_int v.bits.(0))
                     (Int32.shift_left (Int32.of_int (v.bits.(1) land 1)) 30)
     | 64 ->
-        Int32.of_int (v.bits.(0) land 0x7fffffff)
+        Int32.of_int (v.bits.(0) land (Int32.to_int 0x7fffffffl))
     | _ -> assert false
 
 (* this is 0xffffffff (ocaml >= 3.08 checks for literal overflow) *)


### PR DESCRIPTION
When the ocaml compiler emits bytecode for 32-bit architectures, large interger literals will cause it to fail.  32-bit marshalling is most commonly used when compiling with the Js_of_ocaml backend. 

This error message is what you'd see when attempting to use ocamlgraph in a JSOO project: 
 
```
----line 1 of _none_ col 1
File "_none_", line 1:
Error: Generated bytecode library "graph.cma" cannot be used on a 32-bit platform
```

By using [32-bit integer literals](https://v2.ocaml.org/api/Int32.html), we avoid the issue by eschewing platform-native integers.