### PR TITLE
Add Graphviz compound, lhead and ltail attribute support

### DIFF
--- a/src/dGraphTreeLayout.ml
+++ b/src/dGraphTreeLayout.ml
@@ -504,9 +504,9 @@ struct
       attributes_list_to_eattributes eattrs q
     | (`Arrowhead _ | `Arrowsize _ | `Arrowtail _ | `Comment _  | `Constraint _
       | `Headlabel _ | `Headport _ | `Headurl _ | `Labelangle _
-      |`Labeldistance _ | `Labelfloat _ | `Layer _ | `Minlen _ | `Penwidth _
-      | `Samehead _  | `Sametail _ | `Taillabel _ | `Tailport _ | `Tailurl _
-      | `Weight _ ) :: q ->
+      | `Labeldistance _ | `Labelfloat _ | `Layer _ | `Lhead _ | `Ltail _
+      | `Minlen _ | `Penwidth _ | `Samehead _  | `Sametail _ | `Taillabel _
+      | `Tailport _ | `Tailurl _ | `Weight _ ) :: q ->
       attributes_list_to_eattributes eattrs q
 
   let eattrs_to_operation tree e geometry_info =

--- a/src/graphviz.ml
+++ b/src/graphviz.ml
@@ -597,8 +597,8 @@ module DotAttributes = struct
   (** Attributes of graphs.  They include all common graph attributes and
       several specific ones.  All attributes described in the "dot User's
       Manual, February 4, 2002" are handled, excepted: clusterank, color,
-      compound, labeljust, labelloc, ordering, rank, remincross, rotate,
-      searchsize and style.
+      labeljust, labelloc, ordering, rank, remincross, rotate, searchsize
+      and style.
   *)
   type graph =
     [ CommonAttributes.graph
@@ -609,6 +609,8 @@ module DotAttributes = struct
         a transparency component. *)
     | `Comment of string
     (** Comment string. *)
+    | `Compound of bool
+    (** If [true], allow edges between clusters.  Default value is [false]. *)
     | `Concentrate of bool
     (** If [true], enables edge concentrators.  Default value is [false]. *)
     | `Fontpath of string
@@ -677,7 +679,7 @@ module DotAttributes = struct
 
   (** Attributes of edges.  They include all common edge attributes and
       several specific ones.  All attributes described in the "dot User's
-      Manual, February 4, 2002" are handled, excepted: lhead and ltail.
+      Manual, February 4, 2002" are handled.
   *)
   type edge =
     [ CommonAttributes.edge
@@ -709,6 +711,10 @@ module DotAttributes = struct
         Default value is [false]. *)
     | `Layer of string
     (** Overlay. *)
+    | `Lhead of string
+    (** Logical head of an edge. *)
+    | `Ltail of string
+    (** Logical tail of an edge. *)
     | `Minlen of int
     (** Minimum rank distance between head an tail.  Default value is [1]. *)
     | `Samehead of string
@@ -753,6 +759,7 @@ module DotAttributes = struct
     | `BgcolorWithTransparency a ->
       fprintf ppf "bgcolor=%a" fprint_color_with_transparency a
     | `Comment s -> fprintf ppf "comment=%a" fprint_string s
+    | `Compound b -> fprintf ppf "compound=%b" b
     | `Concentrate b -> fprintf ppf "concentrate=%b" b
     | `Fontpath s -> fprintf ppf "fontpath=%a" fprint_string s
     | `Layers s -> fprintf ppf "layers=%a" fprint_string_list s
@@ -805,6 +812,8 @@ module DotAttributes = struct
     | `Labeldistance f -> fprintf ppf "labeldistance=%f" f
     | `Labelfloat b -> fprintf ppf "labelfloat=%b" b
     | `Layer s -> fprintf ppf "layer=%a" fprint_string s
+    | `Lhead s -> fprintf ppf "lhead=cluster_%a" fprint_string s
+    | `Ltail s -> fprintf ppf "ltail=cluster_%a" fprint_string s
     | `Minlen i -> fprintf ppf "minlen=%i" i
     | `Samehead s -> fprintf ppf "samehead=%a" fprint_string s
     | `Sametail s -> fprintf ppf "sametail=%a" fprint_string s

--- a/src/graphviz.mli
+++ b/src/graphviz.mli
@@ -236,8 +236,8 @@ module DotAttributes : sig
   (** Attributes of graphs.  They include all common graph attributes and
       several specific ones.  All attributes described in the "dot User's
       Manual, February 4, 2002" are handled, excepted: clusterank, color,
-      compound, labeljust, labelloc, ordering, rank, remincross, rotate,
-      searchsize and style. *)
+      labeljust, labelloc, ordering, rank, remincross, rotate, searchsize
+      and style. *)
   type graph =
     [ CommonAttributes.graph
     | `Bgcolor of color
@@ -247,6 +247,8 @@ module DotAttributes : sig
         a transparency component. *)
     | `Comment of string
     (** Comment string. *)
+    | `Compound of bool
+    (** If [true], allow edges between clusters.  Default value is [false]. *)
     | `Concentrate of bool
     (** If [true], enables edge concentrators.  Default value is [false]. *)
     | `Fontpath of string
@@ -314,7 +316,7 @@ module DotAttributes : sig
 
   (** Attributes of edges.  They include all common edge attributes and
       several specific ones.  All attributes described in the "dot User's
-      Manual, February 4, 2002" are handled, excepted: lhead and ltail. *)
+      Manual, February 4, 2002" are handled. *)
   type edge =
     [ CommonAttributes.edge
     | `Arrowhead of arrow_style
@@ -345,6 +347,10 @@ module DotAttributes : sig
         Default value is [false]. *)
     | `Layer of string
     (** Overlay. *)
+    | `Lhead of string
+    (** Logical head of an edge. *)
+    | `Ltail of string
+    (** Logical tail of an edge. *)
     | `Minlen of int
     (** Minimum rank distance between head an tail.
         Default value is [1]. *)


### PR DESCRIPTION
Since clusters are already supported by the `Graphviz` module, it makes sense to allow edges from/to them.