### PR TITLE
Remove the useless dependency on stdlib-shims

### DIFF
--- a/dgraph/dune
+++ b/dgraph/dune
@@ -2,7 +2,7 @@
  (name graph_gtk)
  (public_name ocamlgraph_gtk)
  (modules :standard \ dGraphViewer)
- (libraries ocamlgraph stdlib-shims lablgtk2.gnomecanvas lablgtk2)
+ (libraries ocamlgraph lablgtk2.gnomecanvas lablgtk2)
  (flags -open Graph))
 
 (executable

--- a/ocamlgraph.opam
+++ b/ocamlgraph.opam
@@ -19,7 +19,6 @@ doc: "https://backtracking.github.io/ocamlgraph"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues/new"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "stdlib-shims"
   "dune" {>= "2.0"}
   "graphics" {with-test}
 ]

--- a/ocamlgraph_gtk.opam
+++ b/ocamlgraph_gtk.opam
@@ -19,7 +19,6 @@ doc: "https://backtracking.github.io/ocamlgraph"
 bug-reports: "https://github.com/backtracking/ocamlgraph/issues/new"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "stdlib-shims"
   "lablgtk"
   "conf-gnomecanvas"
   "ocamlgraph" {>= "2.0.0"}

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,6 @@
 (library
  (name graph)
  (public_name ocamlgraph)
- (libraries stdlib-shims)
  (modules_without_implementation dot_ast sig sig_pack))
 
 (ocamlyacc dot_parser)


### PR DESCRIPTION
ocamlgraph already requires OCaml >= 4.08 which makes stdlib-shims a no-op