### PR TITLE
fix documentation and add `shell.nix`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@
 /www/index.fr.html
 /www/version.prehtml
 _build
+*.install
 
 _opam

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,16 @@
+{ pkgs ? import (builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz";
+  }) {}
+}:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs.ocamlPackages; [
+    dune_3
+    findlib
+    ocaml
+    lablgtk
+  ];
+  buildInputs = with pkgs.ocamlPackages; [
+    graphics
+  ];
+}

--- a/src/persistent.mli
+++ b/src/persistent.mli
@@ -73,12 +73,12 @@ module Digraph : sig
       standard concrete directional graphs. But accessing predecessors and
       removing a vertex are faster. *)
 
-  (** Imperative Unlabeled, bidirectional graph. *)
+  (** Persistent Unlabeled, bidirectional graph. *)
   module ConcreteBidirectional (V: COMPARABLE) :
     Sig.P with type V.t = V.t and type V.label = V.t and type E.t = V.t * V.t
                                                      and type E.label = unit
 
-  (** Imperative Labeled and bidirectional graph. *)
+  (** Persistent Labeled and bidirectional graph. *)
   module ConcreteBidirectionalLabeled(V:COMPARABLE)(E:ORDERED_TYPE_DFT) :
     Sig.P with type V.t = V.t and type V.label = V.t
                               and type E.t = V.t * E.t * V.t and type E.label = E.t


### PR DESCRIPTION
Hi,

I noticed what I believe to be a copy-paste error in the documentation of `Persistent.Digraph.ConcreteBidirectional` and `Persistent.Digraph.ConcreteBidirectionalLabeled`, they were both documented as being imperative but I believe it should have been saying "Persistent" instead.

I also added a `shell.nix` so people using Nix can contribute more easily to the project. And I added an entry in the `.gitignore` file for something that I noticed to be generated but not ignored.

Best,