### PR TITLE
Correctly set `labelfontcolor`

### DIFF
--- a/src/dGraphTreeLayout.ml
+++ b/src/dGraphTreeLayout.ml
@@ -491,7 +491,7 @@ struct
       eattrs.html_label <- set_if_none eattrs.html_label l;
       attributes_list_to_eattributes eattrs q
     | `Labelfontcolor c :: q ->
-      eattrs.fontcolor <- set_if_none eattrs.fontcolor c;
+      eattrs.labelfontcolor <- set_if_none eattrs.labelfontcolor c;
       attributes_list_to_eattributes eattrs q
     | `Labelfontname n :: q ->
       eattrs.labelfontname <- set_if_none eattrs.labelfontname n;


### PR DESCRIPTION
If I'm not mistaken there's both [`fontcolor`](https://graphviz.org/docs/attrs/fontcolor/) and [`labelfontcolor`](https://graphviz.org/docs/attrs/labelfontcolor/) and in this case the `` `Labelfontcolor`` polymorphic variant was mapped to `eattrs.fontcolor` field, making the `labelfontcolor` field unused. Correct that by mapping the variant to the correct field.